### PR TITLE
docs: simplify config, add Chinese README, and update archetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,98 @@
+# 灿若星河 · Hugo 个人网站
+
+这是 [philohao.com](https://philohao.com/) 的 Hugo 源码仓库，当前使用 `aether` 主题，内容以中文为主，主要记录：
+
+- **生活与月报**：碎碎念、阶段复盘、个人观察；
+- **技术折腾**：Hugo 建站、样式改造、工具实践；
+- **读看听**：书籍、电影/剧集、自媒体摘录与年度记录；
+- **万里路**：旅行、徒步、城市与照片记录。
+
+## 目录结构
+
+```text
+.
+├── archetypes/              # hugo new 生成文章时使用的模板
+├── config.toml              # Hugo 与主题主配置，已按当前站点用途写中文注释
+├── content/
+│   ├── pages/               # 独立页面：足迹、阅览、关于
+│   └── posts/<year>/        # 按年份存放的文章与月报
+├── data/
+│   ├── books.yaml           # 阅览页的书籍数据
+│   └── movies.yaml          # 阅览页的影剧数据
+├── static/images/me/        # favicon、logo、头像、二维码等个人静态资源
+└── themes/aether/           # Aether 主题子模块
+```
+
+## 内容维护约定
+
+### 新建文章
+
+推荐使用 Hugo archetype 生成基础 front matter：
+
+```bash
+hugo new content/posts/2026/20260509.md
+```
+
+生成后重点检查这些字段：
+
+- `title`：文章标题；
+- `date`：发布时间；
+- `description`：用于 SEO、分享卡片和搜索摘要；
+- `categories`：建议从 `碎碎念`、`爱折腾`、`读看听`、`万里路` 中选择；
+- `series`：同主题合集，不需要时保持 `[]`；
+- `tags`：建议 2-5 个；
+- `comment`、`toc`、`math`：按单篇文章需要覆盖全站默认值。
+
+### 独立页面
+
+- `content/pages/footprint.md`：足迹和旅行照片；
+- `content/pages/mentalfood.md`：书影音游入口，正文通过短代码读取 `data/` 数据；
+- `content/pages/about.md`：个人介绍与站点说明。
+
+### 书影音数据
+
+`data/books.yaml` 与 `data/movies.yaml` 是“阅览”页的数据源。新增条目时建议保持同一年份分组和既有字段风格，避免把大量数据重新写回 Markdown 页面。
+
+## 配置维护说明
+
+主要配置都在 `config.toml`，已按“当前实际使用 + 后续常改”整理。常见修改位置如下：
+
+| 修改目标 | 配置位置 | 说明 |
+| --- | --- | --- |
+| 站点标题、描述、关键词 | `[params]` | 影响首页、SEO 和分享摘要 |
+| 顶部导航 | `[[menu.main]]` | 对应归档、足迹、阅览、关于 |
+| 首页头像与副标题 | `[params.home.profile]` | 头像资源位于 `static/images/me/` |
+| 社交链接 | `[params.social]` | 目前只保留 Email、GitHub、Mastodon、RSS、Telegram |
+| 评论系统 | `[params.page.comment.giscus]` | 当前使用 Giscus；仓库或 Discussions 分类变化时需同步 ID |
+| 搜索 | `[params.search]` | 当前使用本地 Fuse 搜索，`outputs.home` 中的 `JSON` 不要删除 |
+| Markdown 原文链接 | `[params.page]` 与 `[outputs]` | `linkToMarkdown = true` 依赖 `page = ["HTML", "MarkDown"]` |
+| Cookie/统计 | `[params.analytics]`、`[params.cookieconsent]` | 暂未配置统计 ID，默认关闭 |
+
+## 本地预览
+
+首次拉取仓库后需要初始化主题子模块：
+
+```bash
+git submodule update --init --recursive
+```
+
+启动本地服务：
+
+```bash
+hugo server -D
+```
+
+生成静态文件：
+
+```bash
+hugo --gc --minify
+```
+
+> 如果主题子模块无法下载，Hugo 构建会失败；先确认网络或手动检查 `.gitmodules` 中的主题仓库地址。
+
+## 维护提醒
+
+- 文章图片优先使用稳定的图床链接；个人站点图标、Logo、头像放在 `static/images/me/`。
+- `config.toml` 中的中文注释是后续改配置的参考，删除配置前先确认主题是否仍依赖该项。
+- `enableGitInfo = true` 会依赖 Git 历史计算更新时间；如果在无 Git 环境部署，需要确认构建平台是否保留 `.git` 信息。
+- 站点目前以中文内容为主，保留 `hasCJKLanguage = true`。

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,12 +1,19 @@
 ---
 title: "{{ replace .Name "-" " " | title }}"
 date: {{ .Date }}
-categories: [碎碎念, 爱折腾, 读看听, 万里路]
-series: [夕拾花]
+description: ""
+
+# 常用分类：碎碎念（生活随笔）、爱折腾（技术/工具/建站）、读看听（书影音游）、万里路（旅行/户外）。
+categories: []
+# 系列用于归并同一主题的文章；不需要时保持空数组。
+series: []
+# 标签建议 2-5 个，使用中文或明确的英文技术名词。
 tags: []
+
+# 单篇文章可覆盖全站配置：是否开启评论、目录、数学公式等。
 comment: true
-toc: false
+toc: true
+math: false
 ---
 
-
-（yyyy-mm-dd@xx）
+（yyyy-mm-dd@地点）

--- a/config.toml
+++ b/config.toml
@@ -1,123 +1,96 @@
 baseURL = "https://philohao.com/"
-# [en, zh-cn, fr, ...] 设置默认的语言
-defaultContentLanguage = "zh-cn"
-# 网站语言, 仅在这里 CN 大写
-languageCode = "zh-CN"
-# 是否包括中日韩文字
-hasCJKLanguage = true
-
-# 更改使用 Hugo 构建网站时使用的默认主题
+title = "灿若星河 | 郝建锋"
 theme = "aether"
 
-title = "JianFeng Hao | 郝建锋"
+# 站点语言：中文内容为主，开启 CJK 支持可让摘要、字数统计等更准确。
+defaultContentLanguage = "zh-cn"
+languageCode = "zh-CN"
+hasCJKLanguage = true
+
+# 生成 Git 修改时间，供文章 lastmod、最近更新列表等功能使用。
+enableGitInfo = true
+
+# 站点结构约定：
+# - content/posts/<year>/：按年份归档的博文与月报
+# - content/pages/：独立页面，例如足迹、阅览、关于
+# - data/books.yaml、data/movies.yaml：阅览页使用的数据源
+# - static/images/me/：站点头像、Logo、favicon 等个人素材
+
+[frontmatter]
+# 文章最后更新时间的读取顺序：优先 Git，其次文件修改时间，再读取 front matter。
+lastmod = [":git", ":fileModTime", "lastmod", ":default"]
 
 [menu]
 [[menu.main]]
 identifier = "posts"
 name = "归档"
-post = ""
 pre = "🗃️"
 title = "所有文章"
 url = "/posts/"
 weight = 1
-# [[menu.main]]
-# identifier = ""
-# # 你可以在名称 (允许 HTML 格式) 之前添加其他信息, 例如图标
-# pre = "🗃️"
-# # 你可以在名称 (允许 HTML 格式) 之后添加其他信息, 例如图标
-# name = "夕拾花"
-# post = ""
-# url = "/series/夕拾花/"
-# # 当你将鼠标悬停在此菜单链接上时, 将显示的标题
-# title = "生活、月报类文章"
-# weight = 2
+
 [[menu.main]]
-identifier = ""
+identifier = "footprint"
 name = "足迹"
-post = ""
 pre = "🌏"
 title = "行万里路"
 url = "/pages/footprint/"
 weight = 2
+
 [[menu.main]]
-identifier = ""
+identifier = "mentalfood"
 name = "阅览"
-post = ""
 pre = "🎡"
 title = "书影音游"
 url = "/pages/mentalfood/"
 weight = 3
-# [[menu.main]]
-# identifier = ""
-# name = "关于"
-# post = ""
-# pre = "👨‍🔧"
-# title = "关于我以及我的网站"
-# url = "/pages/about/"
-# weight = 4
+
+[[menu.main]]
+identifier = "about"
+name = "关于"
+pre = "👨‍🔧"
+title = "关于我以及这个网站"
+url = "/pages/about/"
+weight = 4
 
 [params]
-#  DoIt 主题版本
+# Aether 主题继承/兼容 DoIt 系配置；这里只保留本站正在使用或后续常改的选项。
 version = "0.2.X"
-# 网站名称
 title = "灿若星河"
-# 网站描述
-description = "Personal website of JianFeng Hao | 郝建锋的个人网站"
-# 网站关键词
-keywords = ["blog", "Hugo", "郝建锋", "博客"]
-#  网站默认主题样式 ("light", "dark", "black", "auto")
+description = "郝建锋的个人网站，记录生活、阅读、旅途与技术折腾。"
+keywords = ["郝建锋", "灿若星河", "Hugo", "个人博客", "阅读", "旅行", "技术折腾"]
 defaultTheme = "auto"
-# 公共 git 仓库路径, 仅在 enableGitInfo 设为 true 时有效
-enableGitInfo = true
-[frontmatter]
-  lastmod = [":git", ":fileModTime", "lastmod", ":defalut"]
-
-gitRepo = ""
-#  哪种哈希函数用来 SRI, 为空时表示不使用 SRI
-# ("sha256", "sha384", "sha512", "md5")
-fingerprint = "md5"
-#  日期格式
 dateFormat = "2006-01-02"
-# 网站图片, 用于 Open Graph 和 Twitter Cards
+fingerprint = "md5"
+gitRepo = "https://github.com/DivinerHJF/hugo-blog-Aether"
 images = ["/images/me/favicon.svg"]
-#  开启PWA支持
 enablePWA = true
-#  应用图标配置
+
 [params.app]
-# 当添加到 iOS 主屏幕或者 Android 启动器时的标题, 覆盖默认标题
-title = "Aether"
-# 是否隐藏网站图标资源链接
+# PWA / 移动端添加到主屏幕时使用的名称与图标。
+title = "灿若星河"
 noFavicon = false
-# 更现代的 SVG 网站图标, 可替代旧的 .png 和 .ico 文件
 svgFavicon = "/images/me/favicon.svg"
-# Safari 图标颜色
 iconColor = "#5bbad5"
-# Windows v8-10磁贴颜色
 tileColor = "#da532c"
 
-#  搜索配置
 [params.search]
+# 本地 Fuse 搜索。若改用 Algolia，再补充下方 algolia 密钥。
 enable = true
-# 搜索引擎的类型 ("lunr", "algolia", "fuse")
 type = "fuse"
-# 文章内容最长索引长度
 contentLength = 1000000
-# 搜索框的占位提示语
-placeholder = ""
-#  最大结果数目
+placeholder = "搜索文章"
 maxResultLength = 10
-#  结果内容片段长度
 snippetLength = 50
-#  搜索结果中高亮部分的 HTML 标签
 highlightTag = "em"
-#  是否在搜索索引中使用基于 baseURL 的绝对路径
 absoluteURL = false
+
 [params.search.algolia]
 appID = ""
 index = ""
 searchKey = ""
+
 [params.search.fuse]
-#  https://fusejs.io/api/options.html
 findAllMatches = false
 ignoreFieldNorm = false
 isCaseSensitive = false
@@ -129,518 +102,227 @@ threshold = 0.3
 distance = 100
 useExtendedSearch = false
 
-# 页面头部导航栏配置
 [params.header]
-# 桌面端导航栏模式 ("fixed", "normal", "auto")
 desktopMode = "auto"
-# 移动端导航栏模式 ("fixed", "normal", "auto")
 mobileMode = "auto"
-#  主题切换模式
-# 主题切换模式 ("switch", "select")
 themeChangeMode = "select"
-#  页面头部导航栏标题配置
+
 [params.header.title]
-# LOGO 的 URL
 logo = "/images/me/logo.svg"
-# 标题名称
 name = "星河一方"
-# 你可以在名称 (允许 HTML 格式) 之前添加其他信息, 例如图标
 pre = ""
-# 你可以在名称 (允许 HTML 格式) 之后添加其他信息, 例如图标
 post = ""
-#  是否为标题显示打字机动画
 typeit = false
 
-# 页面底部信息配置
 [params.footer]
 enable = true
-#  自定义内容 (支持 HTML 格式)
-custom = '<a href="/categories/" target="_blank" rel="noreferrer">分类</a> · <a href="/tags/" target="_blank">标签</a> · <a href="/series/" target="_blank">系列</a> <hr width="20px" color="#D3D3D3">'
-#  是否显示 Hugo 和主题信息
+custom = '<a href="/categories/" target="_blank" rel="noreferrer">分类</a> · <a href="/tags/" target="_blank" rel="noreferrer">标签</a> · <a href="/series/" target="_blank" rel="noreferrer">系列</a> <hr width="20px" color="#D3D3D3">'
 hugo = false
-#  是否显示版权信息
 copyright = true
-#  是否显示作者
 author = true
-# 网站创立年份
 since = 2017
-# ICP 备案信息, 仅在中国使用 (支持 HTML 格式)
 icp = ""
-# 许可协议信息 (支持 HTML 格式)
-# license = '<a rel="license external nofollow noopener noreffer" href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC BY-NC 4.0</a>'
 
-#  Section (所有文章) 页面配置
 [params.section]
-# section 页面每页显示文章数量
 paginate = 10000
-# 日期格式 (月和日)
 dateFormat = "01-02"
-# RSS 文章数目
 rss = 100
-#  最近更新文章设置
+
 [params.section.recentlyUpdated]
-days = 30
 enable = true
+days = 30
 maxCount = 5
 rss = true
 
-#  List (目录或标签) 页面配置
 [params.list]
-# list 页面每页显示文章数量
 paginate = 1000
-# 日期格式 (月和日)
 dateFormat = "01-02"
-# RSS 文章数目
 rss = 100
 
-# 主页配置
 [params.home]
-#  RSS 文章数目
 rss = 100
-# 主页个人信息
+
 [params.home.profile]
 enable = true
-# Gravatar 邮箱, 用于优先在主页显示的头像
 gravatarEmail = ""
-# 主页显示头像的 URL
-# 将你的头像文件放置于 static 或者 assets 目录下
-# 文件路径是相对于 static 或者 assets 目录的
 avatarURL = "/images/me/avatar.svg"
-#  主页显示的网站标题 (支持 HTML 格式)
-title = "Aether"
-# 主页显示的网站副标题
-subtitle = "Okay guys class is over ...."
-# 是否为副标题显示打字机动画
+title = "灿若星河"
+subtitle = "记录生活、阅读、旅途与技术折腾。"
 typeit = false
-# 是否显示社交账号
 social = true
-#  免责声明 (支持 HTML 格式)
 disclaimer = ""
-# 主页文章列表
+
 [params.home.posts]
+# 首页当前只展示个人信息；如需首页文章流，将 enable 改为 true。
 enable = false
-# 主页每页显示文章数量
 paginate = 6
-#  被 params.page 中的 hiddenFromHomePage 替代
-# 当你没有在文章前置参数中设置 "hiddenFromHomePage" 时的默认行为
 defaultHiddenFromHomePage = false
 
-# 作者的社交信息设置
-# 所有支持的社交链接的默认数据位于 themes/DoIt/assets/data/social.yaml. 你可以参考它来配置你的社交链接.
 [params.social]
-Angellist = ""
-Bandcamp = ""
-Behance = ""
-Bilibili = ""
-Bitbucket = ""
-BuyMeACoffee = ""
-Codepen = ""
-Deviantart = ""
-Devto = ""
-Douban = ""
-Dribbble = ""
+# 仅保留已使用的社交入口，避免大量空配置干扰后续维护。
 Email = "haojianfeng1997@gmail.com"
-Facebook = ""
-Fivehundredpx = ""
-Flickr = ""
-Foursquare = ""
-FreeCodeCamp = ""
 GitHub = "DivinerHJF"
-Gitea = ""
-Gitlab = ""
-Goodreads = ""
-Googlescholar = ""
-Hackernews = ""
-Instagram = ""
-Jsfiddle = ""
-Keybase = ""
-Kickstarter = ""
-Ko-Fi = ""
-Lastfm = ""
-Liberapay = ""
-Linkedin = ""
-Linktree = ""
 Mastodon = "@PhiloHao"
-Matrix = ""
-Medium = ""
-Mix = ""
-ORCID = ""
-Odnoklassniki = ""
-Patreon = ""
-Paypal = ""
-Pinterest = ""
-QQGroup = ""
-Quora = ""
 RSS = true
-Reddit = ""
-Researchgate = ""
-Skype = ""
-Slidershare = ""
-Snapchat = ""
-Soundcloud = ""
-Spotify = ""
-Stackoverflow = ""
-Steam = ""
-Strava = ""
 Telegram = "Aether_Q"
-Thingiverse = ""
-Tumblr = ""
-Twitch = ""
-Twitter = ""
-VK = ""
-Vine = ""
-Weibo = ""
-Whatsapp = ""
-Wordpress = ""
-XMPP = ""
-Xing = ""
-Youtubechannel = ""
-Youtubecustom = ""
-Youtubelegacy = ""
-Zhihu = ""
 
-#  文章页面配置
 [params.page]
-#  是否在主页隐藏一篇文章
 hiddenFromHomePage = false
-#  是否在搜索结果中隐藏一篇文章
 hiddenFromSearch = false
-#  是否使用 twemoji
 twemoji = false
-# 是否使用 lightgallery
 lightgallery = false
-#  是否使用 ruby 扩展语法
 ruby = true
-#  是否使用 fraction 扩展语法
 fraction = true
-#  是否使用 fontawesome 扩展语法
 fontawesome = true
-# 是否在文章页面显示原始 Markdown 文档链接
 linkToMarkdown = true
-#  是否在 RSS 中显示全文内容
 rssFullText = true
-#  页面样式 ("normal", "wide")
 pageStyle = "normal"
-#  过时文章提示
+
 [params.page.outdatedArticleReminder]
+# 旧文提醒会让长尾文章显得更审慎；若觉得干扰阅读，可关闭 enable。
 enable = true
-# 如果文章最后更新于 90 天之前，显示提醒
 reminder = 90
-# 如果文章最后更新于 180 天之前，显示警告
 warning = 180
-#  目录配置
+
 [params.page.toc]
-# 是否使用目录
 enable = true
-#  是否保持使用文章前面的静态目录
 keepStatic = false
-# 是否使侧边目录自动折叠展开
 auto = false
-#  代码配置
+
 [params.page.code]
-# 是否显示代码块的复制按钮
 copy = true
-# 默认展开显示的代码行数
 maxShownLines = 15
-#  KaTeX 数学公式
+
 [params.page.math]
 enable = true
-# 默认块定界符是 $$ ... $$ 和 \\[ ... \\]
 blockLeftDelimiter = ""
 blockRightDelimiter = ""
-# 默认行内定界符是 $ ... $ 和 \\( ... \\)
 inlineLeftDelimiter = ""
 inlineRightDelimiter = ""
-# KaTeX 插件 copy_tex
 copyTex = true
-# KaTeX 插件 mhchem
 mhchem = true
-#  Mapbox GL JS 配置
+
 [params.page.mapbox]
-# Mapbox GL JS 的 access token
+# 目前没有启用地图；填写 accessToken 后再在文章中使用地图短代码。
 accessToken = ""
-# 浅色主题的地图样式
 lightStyle = "mapbox://styles/mapbox/light-v9"
-# 深色主题的地图样式
 darkStyle = "mapbox://styles/mapbox/dark-v9"
-# 是否添加 NavigationControl
 navigation = true
-# 是否添加 GeolocateControl
 geolocate = true
-# 是否添加 ScaleControl
 scale = true
-# 是否添加 FullscreenControl
 fullscreen = true
-#  文章页面的分享信息设置
+
 [params.page.share]
-Baidu = false
-Blogger = false
-Buffer = false
-Digg = false
+enable = true
 Evernote = true
-Facebook = false
-Flipboard = false
-HackerNews = false
-Instapaper = false
-Line = false
-Linkedin = false
-Mix = false
-Myspace = false
-Odnoklassniki = false
-Pinterest = false
 Pocket = true
 Reddit = true
-Renren = false
-Skype = false
-Stumbleupon = false
-Trello = false
-Tumblr = false
 Twitter = true
-VK = false
 Weibo = true
-Whatsapp = false
-Xing = false
-enable = true
-#  评论系统设置
+
 [params.page.comment]
 enable = true
-# Disqus 评论系统设置
-[params.page.comment.disqus]
-# 
-enable = false
-# Disqus 的 shortname, 用来在文章中启用 Disqus 评论系统
-shortname = ""
-# Gitalk 评论系统设置
-[params.page.comment.gitalk]
-# 
-clientId = ""
-clientSecret = ""
-enable = false
-owner = ""
-repo = ""
-# Valine 评论系统设置
-[params.page.comment.valine]
-appId = ""
-appKey = ""
-avatar = "mp"
-enable = false
-enableQQ = false
-highlight = true
-lang = ""
-meta = ""
-pageSize = 10
-placeholder = ""
-recordIP = true
-serverURLs = ""
-visitor = true
-#  emoji 数据文件名称, 默认是 "google.yml"
-# ("apple.yml", "google.yml", "facebook.yml", "twitter.yml")
-# 位于 "themes/DoIt/assets/data/emoji/" 目录
-# 可以在你的项目下相同路径存放你自己的数据文件:
-# "assets/data/emoji/"
-emoji = ""
-# Waline 评论系统设置
-[params.page.comment.waline]
-# 
-commentCount = true
-emoji = ['https://cdn.jsdelivr.net/gh/walinejs/emojis/weibo']
-enable = false
-highlight = true
-login = 'enable'
-mathTagSupport = true
-meta = ['nick', 'mail', 'link']
-pageSize = 10
-requiredMeta = []
-serverURL = "https://blog-commit-api.vercel.app/"
-uploadImage = true
-visitor = true
-wordLimit = 0
-# Facebook 评论系统设置
-[params.page.comment.facebook]
-appId = ""
-enable = false
-languageCode = "zh_CN"
-numPosts = 10
-width = "100%"
-#  Telegram Comments 评论系统设置
-[params.page.comment.telegram]
-color = ""
-colorful = true
-dark = false
-dislikes = false
-enable = false
-height = ""
-limit = 5
-outlined = false
-siteID = ""
-#  Commento 评论系统设置
-[params.page.comment.commento]
-enable = false
-#  Utterances 评论系统设置
-[params.page.comment.utterances]
-enable = false
-# owner/repo
-darkTheme = "github-dark"
-issueTerm = "pathname"
-label = ""
-lightTheme = "github-light"
-repo = ""
-#  Twikoo 评论系统设置
-[params.page.comment.twikoo]
-commentCount = true
-enable = false
-envId = ""
-path = ""
-region = ""
-visitor = true
-#  Vssue 评论系统设置
-[params.page.comment.vssue]
-clientId = "" 
-clientSecret = "" 
-enable = false 
-owner = "" 
-platform = "" # ("bitbucket", "gitea", "gitee", "github", "gitlab")
-repo = "" 
-#  Remark42 评论系统设置
-[params.page.comment.remark42]
-enable = false
-host = ""
-max_shown_comments = 15
-show_email_subscription = true
-simple_view = false
-site_id = ""
-#  giscus 评论系统设置
+
 [params.page.comment.giscus]
+# 当前实际使用的评论系统。仓库或 Discussions 分类变更时，同步更新以下 ID。
 enable = true
-# owner/repo
+dataRepo = "DivinerHJF/hugo-blog-Aether"
+dataRepoId = "MDEwOlJlcG9zaXRvcnkzNDk5NTUwODc="
 dataCategory = "Comments"
 dataCategoryId = "DIC_kwDOFNvkD84Cvoxi"
 dataMapping = "pathname"
 dataReactionsEnabled = "1"
 dataEmitMetadata = "0"
-dataRepo = "DivinerHJF/hugo-blog-Aether"
-dataRepoId = "MDEwOlJlcG9zaXRvcnkzNDk5NTUwODc="
 dataTheme = "catppuccin_latte"
-#  第三方库配置
+
 [params.page.library]
 [params.page.library.css]
-# someCSS = "some.css"
-# 位于 "assets/"
-# 或者
-# someCSS = "https://cdn.example.com/some.css"
+# 自定义 CSS 示例：custom = "css/custom.css"，文件路径相对 assets/。
 [params.page.library.js]
-# someJavascript = "some.js"
-# 位于 "assets/"
-# 或者
-# someJavascript = "https://cdn.example.com/some.js"
-#  页面 SEO 配置
+# 自定义 JS 示例：custom = "js/custom.js"，文件路径相对 assets/。
+
 [params.page.seo]
-# 图片 URL
 images = []
-# 出版者信息
+
 [params.page.seo.publisher]
-logoUrl = ""
-name = ""
+logoUrl = "/images/me/logo.svg"
+name = "灿若星河"
 
-#  赞赏配置
 [params.sponsor]
-bio = "如果你觉得这篇文章对你有所帮助，欢迎赞赏~" 
-custom = "" # 自定义 HTML 
-enable = false 
-link = "https://www.buymeacoffee.com" # 你的赞赏页面的地址
+enable = false
+bio = "如果你觉得这篇文章对你有所帮助，欢迎赞赏~"
+custom = ""
+link = "https://www.buymeacoffee.com"
 
-#  TypeIt 配置
 [params.typeit]
-# 每一步的打字速度 (单位是毫秒)
 speed = 100
-# 光标的闪烁速度 (单位是毫秒)
 cursorSpeed = 1000
-# 光标的字符 (支持 HTML 格式)
 cursorChar = "|"
-# 打字结束之后光标的持续时间 (单位是毫秒, "-1" 代表无限大)
 duration = -1
 
-# 网站验证代码, 用于 Google/Bing/Yandex/Pinterest/Baidu
 [params.verification]
-baidu = "" 
-bing = "" 
-google = "" 
-pinterest = "" 
-so = "" # 360 search
-sogou = "" 
-yandex = "" 
+# 搜索引擎站长平台验证码；不用时保持空字符串即可。
+baidu = ""
+bing = ""
+google = ""
+pinterest = ""
+so = ""
+sogou = ""
+yandex = ""
 
-#  网站 SEO 配置
 [params.seo]
-# 图片 URL
-image = "https://blog-1255524710.cos.ap-beijing.myqcloud.com/master/2022031021531069866.svg"
-# 缩略图 URL
-thumbnailUrl = "https://blog-1255524710.cos.ap-beijing.myqcloud.com/master/2022031021545432128.svg"
+image = "https://www.philohao.com/images/me/favicon.svg"
+thumbnailUrl = "https://www.philohao.com/images/me/favicon.svg"
 
-#  网站分析配置
 [params.analytics]
-enable = true
-# Google Analytics
+# 暂未配置统计 ID，默认关闭，避免加载无效脚本或误导维护者。
+enable = false
+
 [params.analytics.google]
 id = ""
-# 是否匿名化用户 IP
 anonymizeIP = true
-# Fathom Analytics
+
 [params.analytics.fathom]
 id = ""
-# 自行托管追踪器时的主机路径
 server = ""
-#  Baidu Analytics
+
 [params.analytics.baidu]
 id = ""
-#  Umami Analytics
+
 [params.analytics.umami]
 data_domains = ""
 data_website_id = ""
 src = ""
-#  Plausible Analytics
+
 [params.analytics.plausible]
 data_domain = ""
 src = ""
 
-#  Cookie 许可配置
 [params.cookieconsent]
-enable = true
-# 用于 Cookie 许可横幅的文本字符串
-[params.cookieconsent.content]
-dismiss = ""
-link = ""
-message = ""
+# 没有接入统计/广告前无需弹 Cookie 横幅；接入后再改为 true 并补正文案。
+enable = false
 
-#  第三方库文件的 CDN 设置
+[params.cookieconsent.content]
+dismiss = "知道了"
+link = ""
+message = "本站可能使用 Cookie 改善浏览体验。"
+
 [params.cdn]
-# CDN 数据文件名称, 默认不启用
-# ("jsdelivr.yml")
-# 位于 "themes/DoIt/assets/data/cdn/" 目录
-# 可以在你的项目下相同路径存放你自己的数据文件:
-# "assets/data/cdn/"
+# 默认使用主题内置资源；如要切换 jsdelivr 等 CDN，再配置 data。
 data = ""
 
-#  兼容性设置
 [params.compatibility]
-# 是否使用 Polyfill.io 来兼容旧式浏览器
 polyfill = false
-# 是否使用 object-fit-images 来兼容旧式浏览器
 objectFit = false
 
-# Hugo 解析文档的配置
 [markup]
-# 语法高亮设置
 [markup.highlight]
 codeFences = true
 guessSyntax = true
 lineNos = true
 lineNumbersInTable = true
-# style = "pygments"
-# false 是必要的设置
-# (https://github.com/dillonzq/LoveIt/issues/158)
 noClasses = false
-# Goldmark 是 Hugo 0.60 以来的默认 Markdown 解析库
+
 [markup.goldmark]
 [markup.goldmark.extensions]
 definitionList = true
@@ -650,64 +332,53 @@ strikethrough = true
 table = true
 taskList = true
 typographer = true
+
 [markup.goldmark.renderer]
-# 是否在文档中直接使用 HTML 标签
+# 允许文章直接使用 iframe、HTML 片段等；例如 about 页的 ProcessOn 嵌入。
 unsafe = true
-# 目录设置
+
 [markup.tableOfContents]
-endLevel = 6
 startLevel = 2
+endLevel = 6
 
-# 作者配置
 [author]
-avatar = "https://www.philohao.com/images/me/logo.svg"
-email = "haojianfeng1997@gmail.com"
-gravatarEmail = ""
-link = "https://philohao.com/"
 name = "Jianfeng.Hao"
+email = "haojianfeng1997@gmail.com"
+link = "https://philohao.com/"
+avatar = "https://www.philohao.com/images/me/logo.svg"
+gravatarEmail = ""
 
-# 网站地图配置
 [sitemap]
 changefreq = "weekly"
 filename = "sitemap.xml"
 priority = 0.5
 
-# Permalinks 配置
-[Permalinks]
-# posts = ":year/:month/:filename"
+[permalinks]
 posts = ":year/:month/:filename"
 
-# 隐私信息配置
 [privacy]
-#  Google Analytics 相关隐私 (被 params.analytics.google 替代)
-[privacy.googleAnalytics]
-# ...
 [privacy.twitter]
 enableDNT = true
 [privacy.youtube]
 privacyEnhanced = true
 
-# 用于输出 Markdown 格式文档的设置
 [mediaTypes]
 [mediaTypes."text/plain"]
 suffixes = ["md"]
 
-# 用于输出 Markdown 格式文档的设置
 [outputFormats.MarkDown]
 isHTML = false
 isPlainText = true
 mediaType = "text/plain"
 
-# 用于 Hugo 输出文档的设置
 [outputs]
-# 
+# JSON 用于本地搜索索引；MarkDown 用于文章页“查看原始 Markdown”。
 home = ["HTML", "RSS", "JSON"]
 page = ["HTML", "MarkDown"]
 section = ["HTML", "RSS"]
 taxonomy = ["HTML", "RSS"]
 taxonomyTerm = ["HTML"]
 
-# 用于分类的设置
 [taxonomies]
 author = "authors"
 category = "categories"


### PR DESCRIPTION
### Motivation
- 清理并本地化站点配置，移除或标注过时/冗余项以便后续维护并统一中文注释。  
- 使站点默认行为与当前内容结构一致（菜单、社交、评论、搜索、输出等）。  
- 为新协作者提供中文维护文档和更友好的 `archetypes` 模板以减少上手成本。 

### Description
- 精简并重写 `config.toml`，将站点基础信息、导航、常用 `params` 及注释用中文整理并修正 `frontmatter.lastmod` 默认顺序。  
- 收窄并保留实际使用的社交/评论/搜索/输出配置（例如保留 `giscus` 配置、关闭未配置的 Analytics 与 Cookie 提示、保留本地 `JSON` 输出用于搜索）。  
- 更新 `archetypes/default.md`，添加 `description` 字段，清空默认分类/系列并说明常用分类与单篇覆盖项（`comment`、`toc`、`math`）。  
- 添加 `README.md`（中文），说明站点目的、目录结构、内容维护约定、数据文件用法与本地预览/构建命令。  
- 已将修改提交（提交信息：`docs: update site config and maintenance docs`）。

### Testing
- 运行 `git diff --check` 与用 `python3` 的 `tomllib` 解析 `config.toml`，TOML 解析成功（通过）。  
- 运行 `git submodule update --init --recursive` 在当前环境因网络/权限返回 `CONNECT tunnel failed, response 403`（失败，网络限制导致无法克隆主题子模块）。  
- 尝试运行 `hugo --gc --minify` 失败，环境中未安装 `hugo`（失败／未执行）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff3adb6d048321a6dc3e2ef217d74b)