### PR TITLE
Fix Hugo template else branch parsing

### DIFF
--- a/themes/aether/layouts/partials/post-card.html
+++ b/themes/aether/layouts/partials/post-card.html
@@ -1,5 +1,5 @@
 <article class="post-card">
   <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
   <p class="post-meta"><time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format (.Site.Params.dateFormat | default "2006-01-02") }}</time>{{ with .Params.categories }} · {{ delimit . " / " }}{{ end }}</p>
-  {{ with .Description }}<p>{{ . }}</p>{{ else with .Summary }}<p>{{ . | plainify | truncate 140 }}</p>{{ end }}
+  {{ with .Description }}<p>{{ . }}</p>{{ else }}{{ with .Summary }}<p>{{ . | plainify | truncate 140 }}</p>{{ end }}{{ end }}
 </article>

--- a/themes/aether/layouts/shortcodes/music.html
+++ b/themes/aether/layouts/shortcodes/music.html
@@ -4,6 +4,6 @@
   <div>
     <strong>{{ .Get "name" | default "音乐" }}</strong>
     {{ with .Get "artist" }}<p>{{ . }}</p>{{ end }}
-    {{ if $url }}<audio controls preload="none" src="{{ $url }}"></audio>{{ else with $auto }}<p><a href="{{ . }}" target="_blank" rel="noreferrer">打开音乐链接</a></p>{{ end }}
+    {{ if $url }}<audio controls preload="none" src="{{ $url }}"></audio>{{ else }}{{ with $auto }}<p><a href="{{ . }}" target="_blank" rel="noreferrer">打开音乐链接</a></p>{{ end }}{{ end }}
   </div>
 </div>


### PR DESCRIPTION
### Motivation
- Vercel Hugo build failed with `unexpected <with> in else` because templates used the unsupported `{{ else with ... }}` construct; the change makes the templates compatible with Hugo 0.123.7.

### Description
- Replace `{{ else with ... }}` usages with nested `{{ else }}{{ with ... }}...{{ end }}{{ end }}` in `themes/aether/layouts/partials/post-card.html` and `themes/aether/layouts/shortcodes/music.html` to avoid parse errors during template execution.

### Testing
- Ran `git diff --check` and a template parse smoke test via `go run /tmp/check_templates.go $(rg --files themes/aether/layouts -g '*.html')`, which parsed the templates OK; attempts to run `hugo --gc --minify` and `npx vercel build` were blocked by external registry/download 403 errors so a full Hugo build could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff45570bd0832198500a247604fffc)