### PR TITLE
Prune unused theme configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ hugo new content/posts/2026/20260509.md
 | 首页头像与副标题 | `[params.home.profile]` | 头像资源位于 `static/images/me/` |
 | 社交链接 | `[params.social]` | 目前只保留 Email、GitHub、Mastodon、RSS、Telegram |
 | 评论系统 | `[params.page.comment.giscus]` | 当前使用 Giscus；仓库或 Discussions 分类变化时需同步 ID |
-| 搜索 | `[params.search]` | 当前使用本地 Fuse 搜索，`outputs.home` 中的 `JSON` 不要删除 |
+| 搜索 | `[params.search]` 与 `[params.search.fuse]` | 当前使用本地 Fuse 搜索，`outputs.home` 中的 `JSON` 不要删除 |
+| TypeIt 打字动画 | `[params.typeit]` | 部分月报文章使用 `typeit` 短代码，因此保留全局动画默认值 |
 | Markdown 原文链接 | `[params.page]` 与 `[outputs]` | `linkToMarkdown = true` 依赖 `page = ["HTML", "MarkDown"]` |
-| Cookie/统计 | `[params.analytics]`、`[params.cookieconsent]` | 暂未配置统计 ID，默认关闭 |
 
 ## 本地预览
 

--- a/config.toml
+++ b/config.toml
@@ -76,7 +76,7 @@ iconColor = "#5bbad5"
 tileColor = "#da532c"
 
 [params.search]
-# 本地 Fuse 搜索。若改用 Algolia，再补充下方 algolia 密钥。
+# 本地 Fuse 搜索；若改用 Algolia，需把 type 改为 "algolia" 并重新补充 algolia 配置。
 enable = true
 type = "fuse"
 contentLength = 1000000
@@ -85,11 +85,6 @@ maxResultLength = 10
 snippetLength = 50
 highlightTag = "em"
 absoluteURL = false
-
-[params.search.algolia]
-appID = ""
-index = ""
-searchKey = ""
 
 [params.search.fuse]
 findAllMatches = false
@@ -203,16 +198,6 @@ inlineRightDelimiter = ""
 copyTex = true
 mhchem = true
 
-[params.page.mapbox]
-# 目前没有启用地图；填写 accessToken 后再在文章中使用地图短代码。
-accessToken = ""
-lightStyle = "mapbox://styles/mapbox/light-v9"
-darkStyle = "mapbox://styles/mapbox/dark-v9"
-navigation = true
-geolocate = true
-scale = true
-fullscreen = true
-
 [params.page.share]
 enable = true
 Evernote = true
@@ -249,13 +234,8 @@ images = []
 logoUrl = "/images/me/logo.svg"
 name = "灿若星河"
 
-[params.sponsor]
-enable = false
-bio = "如果你觉得这篇文章对你有所帮助，欢迎赞赏~"
-custom = ""
-link = "https://www.buymeacoffee.com"
-
 [params.typeit]
+# 部分月报文章仍使用 typeit 短代码，这里保留全局动画默认值。
 speed = 100
 cursorSpeed = 1000
 cursorChar = "|"
@@ -279,42 +259,13 @@ thumbnailUrl = "https://www.philohao.com/images/me/favicon.svg"
 # 暂未配置统计 ID，默认关闭，避免加载无效脚本或误导维护者。
 enable = false
 
-[params.analytics.google]
-id = ""
-anonymizeIP = true
-
-[params.analytics.fathom]
-id = ""
-server = ""
-
-[params.analytics.baidu]
-id = ""
-
-[params.analytics.umami]
-data_domains = ""
-data_website_id = ""
-src = ""
-
-[params.analytics.plausible]
-data_domain = ""
-src = ""
-
 [params.cookieconsent]
 # 没有接入统计/广告前无需弹 Cookie 横幅；接入后再改为 true 并补正文案。
 enable = false
 
-[params.cookieconsent.content]
-dismiss = "知道了"
-link = ""
-message = "本站可能使用 Cookie 改善浏览体验。"
-
 [params.cdn]
 # 默认使用主题内置资源；如要切换 jsdelivr 等 CDN，再配置 data。
 data = ""
-
-[params.compatibility]
-polyfill = false
-objectFit = false
 
 [markup]
 [markup.highlight]


### PR DESCRIPTION
### Motivation
- Reduce noise in site `config.toml` by removing theme subfields that are not used by this site and which caused unnecessary maintenance burden.
- Keep only the minimal switches/templates need to decide whether a feature is enabled (for example `enable = false`) so templates can still branch safely.
- Ensure the public-facing README reflects the real set of configuration entry points actually used by the site.

### Description
- Removed unused Algolia credential block and other detailed Algolia fields from `config.toml` while keeping local Fuse search active (`type = "fuse"`).
- Removed the global `[params.page.mapbox]` block and the sponsor block, and removed detailed analytics provider subfields, cookieconsent content block, and compatibility (polyfill/objectFit) subfields; retained the minimal `enable = false` flags for analytics and cookieconsent and kept `[params.typeit]` because some content uses the `typeit` shortcode.
- Updated `README.md` “配置维护说明” table to list only the configuration entries that are actually used (added `params.search.fuse` and `params.typeit` lines and removed the redundant cookie/analytics row).
- Verified template usage: inspection of theme partials shows Algolia is only read when `type = "algolia"`, Mapbox assets are only enqueued when a page sets the `mapbox` scratch flag (shortcode), and TypeIt is still referenced by shortcodes/layouts so global `typeit` defaults are left in place.

### Testing
- Ran Hugo builds after each group of removals with `hugo --gc --minify` and the site built successfully each time (only the existing `author` deprecation warning was emitted). (All builds succeeded.)
- Searched the repo to confirm search remains `fuse` and removed blocks are absent using ripgrep checks such as `rg -n '^type\s*=\s*"fuse"' config.toml` and negative checks for removed blocks; the checks passed.
- Confirmed there are no `mapbox` shortcodes in site `content/` with `rg` and verified TypeIt shortcodes still exist in post content so `[params.typeit]` was kept; those checks passed.
- Verified theme partials still branch on `search.type` and will not read Algolia fields when using Fuse by inspecting `themes/aether/layouts/partials/assets.html` (no template errors introduced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff6eb42518832192d4fa38f7216000)