### PR TITLE
按文章启用 KaTeX 并增强静态库审计的数学探测

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -190,7 +190,7 @@ copy = true
 maxShownLines = 15
 
 [params.page.math]
-enable = true
+enable = false
 blockLeftDelimiter = ""
 blockRightDelimiter = ""
 inlineLeftDelimiter = ""

--- a/content/posts/2018/20180310.md
+++ b/content/posts/2018/20180310.md
@@ -8,6 +8,7 @@ tags:
     - 统计
 comment: true
 toc: true
+math: true
 ---
 
 <center><i>

--- a/content/posts/2018/20180311.md
+++ b/content/posts/2018/20180311.md
@@ -8,6 +8,7 @@ tags:
     - 统计
 comment: true
 toc: true
+math: true
 ---
 
 <center><i>

--- a/content/posts/2018/20180709.md
+++ b/content/posts/2018/20180709.md
@@ -7,6 +7,7 @@ tags:
     - R Markdown
 comment: true
 toc: true
+math: true
 ---
 
 <center>

--- a/scripts/audit-theme-libs.py
+++ b/scripts/audit-theme-libs.py
@@ -24,6 +24,13 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback message
     tomllib = None  # type: ignore[assignment]
 
 SHORTCODE_RE = re.compile(r"{{\s*[<%]\s*(/?)\s*([A-Za-z][A-Za-z0-9_-]*)\b")
+MATH_FEATURE_PATTERNS = {
+    "{{< math >}}": re.compile(r"{{\s*<\s*math\b"),
+    "$$": re.compile(r"\$\$"),
+    "\\[": re.compile(r"\\\["),
+    "\\(": re.compile(r"\\\("),
+}
+FRONT_MATTER_MATH_TRUE_RE = re.compile(r"(?m)^\s*math\s*:\s*true\s*$")
 
 
 @dataclass(frozen=True)
@@ -120,6 +127,36 @@ def scan_shortcodes(content_dir: Path) -> Counter[str]:
     return counts
 
 
+def scan_math_features(content_dir: Path) -> Counter[str]:
+    counts: Counter[str] = Counter()
+    if not content_dir.exists():
+        return counts
+    for path in sorted(content_dir.rglob("*.md")):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        has_formula = False
+        for name, pattern in MATH_FEATURE_PATTERNS.items():
+            matches = pattern.findall(text)
+            if matches:
+                counts[name] += len(matches)
+                has_formula = True
+        if has_formula:
+            counts["__files_with_formula"] += 1
+        if FRONT_MATTER_MATH_TRUE_RE.search(text):
+            counts["__files_with_math_enabled"] += 1
+    return counts
+
+
+def math_feature_summary(math_features: Counter[str]) -> str:
+    visible = [
+        f"{name}={math_features.get(name, 0)}"
+        for name in MATH_FEATURE_PATTERNS
+        if math_features.get(name, 0)
+    ]
+    visible.append(f"公式文章={math_features.get('__files_with_formula', 0)}")
+    visible.append(f"front matter math=true={math_features.get('__files_with_math_enabled', 0)}")
+    return ", ".join(visible)
+
+
 def search_enabled(config: dict[str, Any], search_type: str) -> bool:
     return is_enabled(nested_get(config, "params.search.enable")) and nested_get(config, "params.search.type") == search_type
 
@@ -128,6 +165,12 @@ def comment_enabled(config: dict[str, Any], provider: str) -> bool:
     return is_enabled(nested_get(config, "params.page.comment.enable")) and is_enabled(
         nested_get(config, f"params.page.comment.{provider}.enable")
     )
+
+
+def katex_enabled(config: dict[str, Any], math_features: Counter[str]) -> bool:
+    return is_enabled(nested_get(config, "params.page.math.enable")) or math_features.get(
+        "__files_with_math_enabled", 0
+    ) > 0
 
 
 def shortcode_source(name: str) -> Callable[[dict[str, Any], Counter[str]], str]:
@@ -222,9 +265,10 @@ def build_mappings() -> list[ResourceMapping]:
         ResourceMapping(
             "math.katex",
             ("themes/aether/assets/lib/katex", "themes/aether/static/lib/katex"),
-            lambda config, _shortcodes: is_enabled(nested_get(config, "params.page.math.enable")),
-            lambda config, _shortcodes: "params.page.math.enable="
-            f"{format_value(nested_get(config, 'params.page.math.enable'))}",
+            lambda config, math_features: katex_enabled(config, math_features),
+            lambda config, math_features: "params.page.math.enable="
+            f"{format_value(nested_get(config, 'params.page.math.enable'))}; "
+            f"content math features: {math_feature_summary(math_features)}",
         ),
         ResourceMapping(
             "icons.fontawesome",
@@ -269,11 +313,12 @@ def build_mappings() -> list[ResourceMapping]:
     ]
 
 
-def render_report(root: Path, config: dict[str, Any], shortcodes: Counter[str]) -> str:
+def render_report(root: Path, config: dict[str, Any], shortcodes: Counter[str], math_features: Counter[str]) -> str:
     rows: list[tuple[str, str, str, str, str, str]] = []
     for mapping in build_mappings():
-        active = mapping.trigger(config, shortcodes)
-        source = mapping.source(config, shortcodes)
+        feature_counts = math_features if mapping.feature == "math.katex" else shortcodes
+        active = mapping.trigger(config, feature_counts)
+        source = mapping.source(config, feature_counts)
         for directory in mapping.directories:
             size = directory_size(root / directory)
             rows.append(
@@ -308,6 +353,7 @@ def render_report(root: Path, config: dict[str, Any], shortcodes: Counter[str]) 
         f"- `params.page.twemoji`：{format_value(nested_get(config, 'params.page.twemoji'))}",
         f"- `params.page.lightgallery`：{format_value(nested_get(config, 'params.page.lightgallery'))}",
         f"- `params.page.math.enable`：{format_value(nested_get(config, 'params.page.math.enable'))}",
+        f"- content 数学公式特征：{math_feature_summary(math_features)}",
         f"- `params.page.comment.*.enable`：{comment_summary}",
         f"- `params.cookieconsent.enable`：{format_value(nested_get(config, 'params.cookieconsent.enable'))}",
         f"- `params.social`：{format_value(nested_get(config, 'params.social'))}",
@@ -341,7 +387,8 @@ def main() -> int:
 
     config = read_config(config_path)
     shortcodes = scan_shortcodes(content_dir)
-    print(render_report(root, config, shortcodes))
+    math_features = scan_math_features(content_dir)
+    print(render_report(root, config, shortcodes, math_features))
     return 0
 
 

--- a/themes/aether/layouts/partials/assets.html
+++ b/themes/aether/layouts/partials/assets.html
@@ -87,11 +87,14 @@
 {{- end -}}
 
 {{- /* KaTeX */ -}}
+{{- $siteMath := .Site.Params.page.math | default dict -}}
 {{- $math := $params.math -}}
 {{- if eq $math true -}}
-    {{- $math = .Site.Params.page.math | default dict -}}
+    {{- $math = dict "enable" true | merge $siteMath -}}
 {{- else if eq $math false -}}
     {{- $math = dict "enable" false -}}
+{{- else -}}
+    {{- $math = $math | default dict | merge $siteMath -}}
 {{- end -}}
 {{- if $math.enable -}}
     {{- $source := $cdn.katexCSS | default "lib/katex/katex.min.css" -}}


### PR DESCRIPTION
### Motivation
- 减少不需要数学渲染的页面对 KaTeX 的全站加载开销，同时保留全站数学相关默认配置以便按需启用。 
- 在移除或瘦身主题静态库前，需要更准确地判断 KaTeX 是否真被内容或 front matter 使用以降低误删风险。 
- 暂不删除 Font Awesome 资源，先保留图标替代策略的实施窗口。 

### Description
- 将全站数学默认从 `true` 改为 `false`（`config.toml` 中 `params.page.math.enable`），以关闭默认全站 KaTeX 加载。 
- 在检测到数学公式的 3 篇文章中 front matter 中添加 `math: true`，改为按篇加载 KaTeX（`content/posts/2018/20180310.md`、`...20180311.md`、`...20180709.md`）。 
- 修改 `themes/aether/layouts/partials/assets.html` 的 KaTeX 选择逻辑，使单篇 `math: true` 能基于站点默认配置强制启用该页的 KaTeX（合并 `.Site.Params.page.math` 与页面级 `math`）。 
- 扩展 `scripts/audit-theme-libs.py`，新增对 `{{< math >}}`、`$$`、`\[`、`\(` 等数学特征及 front matter `math: true` 的扫描，并调整 KaTeX 的触发判定为“全站启用或单篇启用”；审计依然保留 Font Awesome/webfonts 目录作为待保留项。 

### Testing
- 运行 `git diff --check` 检查无冲突或多余空白，结果通过（无 error）。 
- 使用 `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile scripts/audit-theme-libs.py` 静态编译脚本以验证语法，结果通过。 
- 执行 `python3 scripts/audit-theme-libs.py >/tmp/audit-theme-libs.md` 以生成审计报告并验证数学特征检测输出，输出包含数学统计（例如 `$$=68, 公式文章=3, front matter math=true=3`）。 
- 使用 `rg` 在 `content/` 中复核数学标记检测，并检查 `themes/aether/assets/lib/fontawesome-free`、`themes/aether/static/lib/webfonts`、`themes/aether/assets/lib/katex` 与 `themes/aether/static/lib/katex` 目录的存在性；结果符合预期。 
- 尝试运行 `hugo --minify` 被跳过（容器中未安装 Hugo），因此未执行站点构建验证。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff7b70323c8321bbbf935b4764b821)