### PR TITLE
Refine light theme color variables

### DIFF
--- a/themes/aether/assets/css/_variables.scss
+++ b/themes/aether/assets/css/_variables.scss
@@ -10,7 +10,7 @@ $global-font-weight: normal !default;
 $global-line-height: 1.8rem !default;
 
 // Color of the background
-$global-background-color: #dfdfdf !default;
+$global-background-color: #f7f7f5 !default;
 $global-background-color-dark: #292a2d !default;
 $global-background-color-black: #000000 !default;
 
@@ -35,7 +35,7 @@ $global-link-hover-color-dark: #fff !default;
 $global-link-hover-color-black: #fff !default;
 
 // Color of the border
-$global-border-color: #b1b1b1 !default;
+$global-border-color: #d8d8d2 !default;
 $global-border-color-dark: #363636 !default;
 $global-border-color-black: #363636 !default;
 // ========== Global ========== //
@@ -60,7 +60,7 @@ $selection-color-black: rgba(50, 112, 194, 0.4) !default;
 $header-height: 3.5rem !default;
 
 // Color of the header background
-$header-background-color: #dcdcdc !default;
+$header-background-color: #ffffffcc !default;
 $header-background-color-dark: #292a2d !default;
 $header-background-color-black: #000000 !default;
 
@@ -74,7 +74,7 @@ $header-active-color-dark: #fff !default;
 $header-active-color-black: #fff !default;
 
 // Color of the search background
-$search-background-color: #e9e9e9 !default;
+$search-background-color: #ffffff !default;
 $search-background-color-dark: #363636 !default;
 $search-background-color-black: #363636 !default;
 // ========== Header ========== //
@@ -95,13 +95,13 @@ $single-link-hover-color-dark: #bdebfc !default;
 $single-link-hover-color-black: #bdebfc !default;
 
 // Color of the table background
-$table-background-color: #efefef !default; 
-$table-background-color-dark: #313236 !default; 
+$table-background-color: #fbfbf8 !default;
+$table-background-color-dark: #313236 !default;
 $table-background-color-black: #313236 !default;
 
 // Color of the table thead
-$table-thead-color: #e9e9e9 !default; 
-$table-thead-color-dark: #27282b !default; 
+$table-thead-color: #f1f2ed !default;
+$table-thead-color-dark: #27282b !default;
 $table-thead-color-black: #27282b !default;
 
 // ========== Single Content ========== //
@@ -125,7 +125,7 @@ $code-color-dark: #E5BF78 !default;
 $code-color-black: #E5BF78 !default;
 
 // Color of the code background
-$code-background-color: #dbdbdb !default;
+$code-background-color: #f1f3f5 !default;
 $code-background-color-dark: #272C34 !default;
 $code-background-color-black: #272C34 !default;
 


### PR DESCRIPTION
### Motivation
- Refresh the light-mode color palette to reduce the overall gray cast and improve reading contrast without large refactors.  
- Make header, search, table and code-block surfaces coordinate with the new background to produce a cleaner, layered appearance.  

### Description
- Update light-mode color variables in `themes/aether/assets/css/_variables.scss` to lighter, fresher values for the page background, header, borders, search, tables and code blocks.  
- Specifically adjust `$global-background-color`, `$header-background-color`, `$global-border-color`, `$search-background-color`, `$table-background-color`, `$table-thead-color`, and `$code-background-color`.  

### Testing
- Ran `git diff --check` to validate whitespace and basic diff cleanliness, which passed.  
- Built the site with `hugo --gc --minify` (local Hugo v0.123.7 extended), and the build completed successfully with only configuration deprecation warnings.  
- Captured light-mode screenshots and computed styles using a headless Playwright script (`node /tmp/aether-shot/screenshot.js`), which produced screenshots and reported expected colors such as `bodyBackground: "rgb(247, 247, 245)"`, `headerBackground: "rgba(255, 255, 255, 0.8)"`, and `searchBackground: "rgb(255, 255, 255)"`, confirming the visual changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff85cc3f748321be8755528ee2340b)