### PR TITLE
Scope decorative fonts to titles and update global/code font stacks

### DIFF
--- a/themes/aether/assets/css/_page/_single.scss
+++ b/themes/aether/assets/css/_page/_single.scss
@@ -3,6 +3,7 @@
 .single {
   .single-title {
     margin: 1rem 0 .5rem;
+    font-family: $decorative-title-font-family;
     font-size: 1.6rem;
     font-weight: bold;
     line-height: 140%;

--- a/themes/aether/assets/css/_variables.scss
+++ b/themes/aether/assets/css/_variables.scss
@@ -4,7 +4,7 @@
 
 // ========== Global ========== //
 // Font and Line Height
-$global-font-family: "KingHwa_OldSong"," LxgwWenKai","LxgwWenKai","JetBrains Mono",monospace !default;
+$global-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", "Noto Sans CJK SC", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif !default;
 $global-font-size: 1rem !default;
 $global-font-weight: normal !default;
 $global-line-height: 1.8rem !default;
@@ -65,7 +65,8 @@ $header-background-color-dark: #292a2d !default;
 $header-background-color-black: #000000 !default;
 
 // Font style of the header title
-$header-title-font-family: $global-font-family !default;
+$decorative-title-font-family: "KingHwa_OldSong", "LxgwWenKai", $global-font-family !default;
+$header-title-font-family: $decorative-title-font-family !default;
 $header-title-font-size: 1.5rem !default;
 
 // Color of the active header menu item
@@ -137,7 +138,7 @@ $code-info-color-black: #b1b0b0 !default;
 $code-font-size: .875rem !default;
 
 // Font family of the code
-$code-font-family: Source Code Pro, Menlo, Consolas, Monaco, monospace, $global-font-family !default;
+$code-font-family: "JetBrains Mono", "Source Code Pro", Menlo, Consolas, Monaco, monospace !default;
 
 // Code type map
 $code-type-map: (


### PR DESCRIPTION
### Motivation
- Replace the global font stack so body text uses a system-first modern Chinese sans-serif stack for better cross-platform rendering and fallback behavior. 
- Remove the accidental leading-space font name and prevent a monospace developer font from affecting site body text. 
- Keep the decorative/handwritten fonts available for titles only so the site can retain personality without impacting readability.

### Description
- Change `$global-font-family` in `themes/aether/assets/css/_variables.scss` to a system-first Chinese sans-serif stack: `-apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", "Noto Sans CJK SC", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif`. 
- Remove the leading-space entry and stop including `"JetBrains Mono"` in the global font stack. 
- Add a new `$decorative-title-font-family` set to `"KingHwa_OldSong", "LxgwWenKai", $global-font-family` and make `$header-title-font-family` inherit it. 
- Move `JetBrains Mono` to the start of `$code-font-family` and remove the fallback to `$global-font-family` from the code stack. 
- Apply the decorative title stack to post titles by setting `.single-title { font-family: $decorative-title-font-family; }` in `themes/aether/assets/css/_page/_single.scss`, while headers continue to inherit `$header-title-font-family`.

### Testing
- Ran `git diff --check` and no whitespace/merge errors were reported, which passed. 
- Compiled the Sass with `npx --yes sass themes/aether/assets/css/style.scss /tmp/aether-style.css` and the stylesheet generated successfully, though the Sass run produced deprecation warnings. 
- Attempted `hugo --minify` but it was not run because `hugo` is not installed in the environment (command returned `hugo: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff86817f3083218e4c49adf544e754)