### PR TITLE
Prefer natural start alignment for article text and lists; add optional justify class

### DIFF
--- a/themes/aether/assets/css/_core/_media.scss
+++ b/themes/aether/assets/css/_core/_media.scss
@@ -55,6 +55,10 @@
     width: 100% !important;
     margin-left: auto !important;
 
+    .single .content p {
+      text-align: start;
+    }
+
     [header-mobile] & {
       padding-top: $header-height;
     }

--- a/themes/aether/assets/css/_page/_single.scss
+++ b/themes/aether/assets/css/_page/_single.scss
@@ -149,7 +149,13 @@
 
     p {
       margin: .5rem 0;
-      text-align: justify;
+      text-align: start;
+    }
+
+    &.prose-justify {
+      p {
+        text-align: justify;
+      }
     }
 
     b, strong {
@@ -191,7 +197,7 @@
     ul, ol {
       margin: .5rem 0;
       padding-left: 2.5rem;
-      text-align: justify;
+      text-align: start;
     }
 
     ul {


### PR DESCRIPTION
### Motivation
- Avoid awkward spacing in mixed-language content by changing paragraph alignment from forced justification to natural start/left alignment.
- Keep an option for two‑sided (justified) Chinese typesetting and ensure small screens use natural alignment for better readability.

### Description
- Update `themes/aether/assets/css/_page/_single.scss` to set `.single .content p { text-align: start; }`, add an optional `.content.prose-justify p { text-align: justify; }`, and change `ul, ol` to `text-align: start;`.
- Update `themes/aether/assets/css/_core/_media.scss` to override paragraph alignment to `text-align: start;` inside the `@media (max-width: 680px)` block for mobile.
- Changes affect single-post content alignment and list alignment to reduce extra gaps after bullets.

### Testing
- Ran `git diff --check` which reported no whitespace or diff-check issues (succeeded).
- Ran `hugo version` but `hugo` was not available in the environment so a local build was not performed (not available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff8683a07883218037a409619cc2e9)