### PR TITLE
Stabilize page responsive width

### DIFF
--- a/themes/aether/assets/css/_core/_media.scss
+++ b/themes/aether/assets/css/_core/_media.scss
@@ -1,14 +1,4 @@
-@media only screen and (max-width: 1440px) {
-  .page {
-    width: 56%;
-  }
-}
-
 @media only screen and (max-width: 1200px) {
-  .page {
-    width: 52%;
-  }
-
   #header-desktop .header-wrapper {
     padding-right: 1rem;
   }
@@ -28,9 +18,15 @@
   }
 
   .page {
-    width: 80% !important;
-    margin-left: auto !important;
-    margin-right: auto !important;
+    max-width: 820px;
+    width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .page.home,
+  .page.archive {
+    max-width: 900px;
   }
 
   #header-desktop .header-wrapper {
@@ -52,8 +48,10 @@
   }
 
   .page {
-    width: 100% !important;
-    margin-left: auto !important;
+    max-width: 100%;
+    width: 100%;
+    margin-left: auto;
+    margin-right: auto;
 
     [header-mobile] & {
       padding-top: $header-height;

--- a/themes/aether/assets/css/_page/_index.scss
+++ b/themes/aether/assets/css/_page/_index.scss
@@ -1,17 +1,27 @@
 .page {
   position: relative;
-  max-width: initial;
-  width: 60%;
+  box-sizing: border-box;
+  max-width: 820px;
+  width: min(100% - 2rem, 820px);
   margin: 0 auto;
+
+  &.home,
+  &.archive {
+    max-width: 900px;
+    width: min(100% - 2rem, 900px);
+  }
+
   [pageStyle=wide][autoTOC=true] & {
-    margin-left: 10%;
+    max-width: 960px;
+    width: min(100% - 2rem, 960px);
+    margin-left: auto;
     margin-right: auto;
-    width: 70%;
   }
   [pageStyle=wide][autoTOC=false] & {
-      width: 70%;
-      margin-left: 15%;
-      margin-right: 15%;
+    max-width: 1040px;
+    width: min(100% - 2rem, 1040px);
+    margin-left: auto;
+    margin-right: auto;
   }
   [header-desktop] & {
     padding-top: $header-height;


### PR DESCRIPTION
### Motivation
- The existing `.page` sizing used multiple percentage breakpoints which produced unstable content widths on different desktop sizes. 
- Non-article pages (home, archive) could appear overly narrow on larger screens due to shared percentage rules. 
- Keep mobile layouts full-width while ensuring the content never touches the viewport edge by relying on the container padding.

### Description
- Replace multi-breakpoint percentage widths with a stable default content cap by updating `themes/aether/assets/css/_page/_index.scss` to use `box-sizing: border-box; max-width: 820px; width: min(100% - 2rem, 820px);` and center with margins. 
- Give home and archive pages a slightly larger cap by adding `.page.home, .page.archive { max-width: 900px; width: min(100% - 2rem, 900px); }` to avoid over-narrow layouts. 
- Simplify wide-page rules so `pageStyle=wide` with `autoTOC=true` uses `max-width: 960px` and without `autoTOC` uses `max-width: 1040px`, both using `width: min(100% - 2rem, …)` and centered margins. 
- Simplify responsive rules in `themes/aether/assets/css/_core/_media.scss` by removing the 1440/1200 percentage breakpoints and ensuring at `max-width: 1000px` the `.page` falls back to `max-width: 820px; width: 100%`, while mobile `max-width: 100%` / `width: 100%` is preserved and existing `.container` padding (`padding: 0 1rem`) prevents text from touching edges.

### Testing
- Ran `git diff --check` and it returned no problems. 
- Compiled the stylesheet with `npx --yes sass themes/aether/assets/css/style.scss /tmp/aether-style.css`, which completed and produced CSS (with deprecation warnings) successfully. 
- Attempted `hugo --gc --minify` but the command failed in the environment with `hugo: command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff868581f0832191830a5ae13ae86a)