### PR TITLE
Optimize font loading: switch to system font stacks and remove external Chinese font CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ hugo new content/posts/2026/20260509.md
 | 搜索 | `[params.search]` 与 `[params.search.fuse]` | 当前使用本地 Fuse 搜索，`outputs.home` 中的 `JSON` 不要删除 |
 | TypeIt 打字动画 | `[params.typeit]` | 部分月报文章使用 `typeit` 短代码，因此保留全局动画默认值 |
 | CDN / 已裁剪可选资源 | `[params.cdn]` | 默认使用仓库内保留的主题资源；Mermaid、ECharts、Mapbox GL 短代码库以及 Twemoji、LightGallery、CookieConsent 本地库已按当前关闭配置移除，重新启用前需配置 CDN 或恢复本地库 |
+| 字体栈 | `themes/aether/assets/css/_variables.scss` | 正文字体、标题装饰字体和代码字体均使用系统字体栈；不再加载外部中文字体 CDN，也不提交字体二进制文件 |
 | Markdown 原文链接 | `[params.page]` 与 `[outputs]` | `linkToMarkdown = true` 依赖 `page = ["HTML", "MarkDown"]` |
 
 ### 主题静态库裁剪

--- a/themes/aether/assets/css/_core/_base.scss
+++ b/themes/aether/assets/css/_core/_base.scss
@@ -1,8 +1,10 @@
 html {
   font-family: $global-font-family;
   font-weight: $global-font-weight;
-  font-display: swap;
   font-size: $global-font-size;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
   line-height: $global-line-height;
   width:100%;
   scroll-behavior: smooth;

--- a/themes/aether/assets/css/_page/_index.scss
+++ b/themes/aether/assets/css/_page/_index.scss
@@ -2,24 +2,24 @@
   position: relative;
   box-sizing: border-box;
   max-width: 820px;
-  width: min(100% - 2rem, 820px);
+  width: unquote("min(100% - 2rem, 820px)");
   margin: 0 auto;
 
   &.home,
   &.archive {
     max-width: 900px;
-    width: min(100% - 2rem, 900px);
+    width: unquote("min(100% - 2rem, 900px)");
   }
 
   [pageStyle=wide][autoTOC=true] & {
     max-width: 960px;
-    width: min(100% - 2rem, 960px);
+    width: unquote("min(100% - 2rem, 960px)");
     margin-left: auto;
     margin-right: auto;
   }
   [pageStyle=wide][autoTOC=false] & {
     max-width: 1040px;
-    width: min(100% - 2rem, 1040px);
+    width: unquote("min(100% - 2rem, 1040px)");
     margin-left: auto;
     margin-right: auto;
   }

--- a/themes/aether/assets/css/_variables.scss
+++ b/themes/aether/assets/css/_variables.scss
@@ -4,10 +4,10 @@
 
 // ========== Global ========== //
 // Font and Line Height
-$global-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", "Noto Sans CJK SC", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif !default;
+$global-font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", "Source Han Sans SC", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "WenQuanYi Micro Hei", sans-serif !default;
 $global-font-size: 1rem !default;
 $global-font-weight: normal !default;
-$global-line-height: 1.8rem !default;
+$global-line-height: 1.8 !default;
 
 // Color of the background
 $global-background-color: #f7f7f5 !default;
@@ -65,7 +65,7 @@ $header-background-color-dark: #292a2d !default;
 $header-background-color-black: #000000 !default;
 
 // Font style of the header title
-$decorative-title-font-family: "KingHwa_OldSong", "LxgwWenKai", $global-font-family !default;
+$decorative-title-font-family: "KingHwa_OldSong", "LXGW WenKai", "STSong", "Songti SC", "SimSun", "Noto Serif CJK SC", serif !default;
 $header-title-font-family: $decorative-title-font-family !default;
 $header-title-font-size: 1.5rem !default;
 
@@ -138,7 +138,7 @@ $code-info-color-black: #b1b0b0 !default;
 $code-font-size: .875rem !default;
 
 // Font family of the code
-$code-font-family: "JetBrains Mono", "Source Code Pro", Menlo, Consolas, Monaco, monospace !default;
+$code-font-family: ui-monospace, SFMono-Regular, "SF Mono", "Cascadia Code", "JetBrains Mono", "Source Code Pro", Menlo, Consolas, Monaco, monospace !default;
 
 // Code type map
 $code-type-map: (

--- a/themes/aether/layouts/partials/head/link.html
+++ b/themes/aether/layouts/partials/head/link.html
@@ -60,11 +60,3 @@
         {{- $_ := $sw.Permalink -}}
     {{- end -}}
 {{- end -}}
-
-
-<link rel="preconnect" href="https://834832894.r.cdn36.com" crossorigin>
-<link rel="preload" as="style" href="https://834832894.r.cdn36.com/chinesefonts3/packages/jhlst/dist/京華老宋体v1_007/result.css">
-<link rel="stylesheet" href="https://834832894.r.cdn36.com/chinesefonts3/packages/jhlst/dist/京華老宋体v1_007/result.css" media="print" onload="this.media='all'">
-<noscript>
-    <link rel="stylesheet" href="https://834832894.r.cdn36.com/chinesefonts3/packages/jhlst/dist/京華老宋体v1_007/result.css">
-</noscript>


### PR DESCRIPTION
### Motivation

- Remove a remote Chinese font stylesheet to avoid runtime dependency on an external CDN and to prevent committing font binaries into the repo.  
- Prefer modern cross-platform system font stacks for body, decorative titles and code for better fallback behavior and performance.  
- Fix a Hugo/LibSass build error caused by unhandled `min()` expressions in SCSS so `hugo --minify` succeeds.  

### Description

- Removed hard-coded external Chinese font CSS (cdn36 / 京華老宋体) from `themes/aether/layouts/partials/head/link.html`.  
- Replaced the body font with a system-first stack and adjusted line-height in `themes/aether/assets/css/_variables.scss`.  
- Replaced decorative title font stack to prefer local Chinese serif/Song fonts (no CDN) in `themes/aether/assets/css/_variables.scss`.  
- Expanded the code font stack to prefer modern system monospace fonts in `themes/aether/assets/css/_variables.scss`.  
- Removed invalid `font-display` usage on `html` and added font smoothing / text-rendering hints in `themes/aether/assets/css/_core/_base.scss`.  
- Quoted `min()` calls (using `unquote(

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff8a9e474c8321838e934eec18da48)