### PR TITLE
Replace ECharts heatmap with Hugo-rendered accessible post heatmap

### DIFF
--- a/themes/aether/layouts/partials/heatmap.html
+++ b/themes/aether/layouts/partials/heatmap.html
@@ -1,194 +1,241 @@
-<div id="heatmap" style="
-  max-width: 600px;
-  height: 140px;
-  padding: 2px;
-  margin: 0 auto;"></div>
+{{- $posts := where .Site.RegularPages "Section" "posts" -}}
+{{- $heatmap := newScratch -}}
+{{- $heatmap.Set "postCount" 0 -}}
+{{- $heatmap.Set "totalWords" 0 -}}
+{{- range $posts -}}
+  {{- $day := .Date.Format "2006-01-02" -}}
+  {{- $wordCount := .WordCount -}}
+  {{- $heatmap.Add "postCount" 1 -}}
+  {{- $heatmap.Add "totalWords" $wordCount -}}
+  {{- $days := $heatmap.Get "days" | default dict -}}
+  {{- $current := index $days $day | default dict -}}
+  {{- $currentCount := add ($current.count | default 0) 1 -}}
+  {{- $currentWords := add ($current.words | default 0) $wordCount -}}
+  {{- $titles := $current.titles | default slice | append .Title -}}
+  {{- $primaryWords := $current.primaryWords | default 0 -}}
+  {{- $primaryLink := $current.primaryLink | default .RelPermalink -}}
+  {{- if gt $wordCount $primaryWords -}}
+    {{- $primaryWords = $wordCount -}}
+    {{- $primaryLink = .RelPermalink -}}
+  {{- end -}}
+  {{- $heatmap.SetInMap "days" $day (dict "count" $currentCount "words" $currentWords "titles" $titles "primaryLink" $primaryLink "primaryWords" $primaryWords) -}}
+{{- end -}}
 
-<script src="https://cdn.jsdelivr.net/npm/echarts@5.3.0/dist/echarts.min.js"></script>
+{{- $days := $heatmap.Get "days" | default dict -}}
+{{- $postCount := $heatmap.Get "postCount" -}}
+{{- $totalWords := $heatmap.Get "totalWords" -}}
+{{- $totalWan := printf "%.1f" (div $totalWords 10000.0) -}}
+{{- $start := (now.AddDate -1 0 0) -}}
+{{- $weekdayIndex := dict "Sun" 0 "Mon" 1 "Tue" 2 "Wed" 3 "Thu" 4 "Fri" 5 "Sat" 6 -}}
+{{- $startWeekday := index $weekdayIndex ($start.Format "Mon") -}}
 
-<script type="text/javascript">
-  // 监听 DOM 加载完成事件，确保在执行脚本时 #heatmap 元素已存在
-  document.addEventListener("DOMContentLoaded", function () {
-    
-    // 获取图表容器
-    var chartDom = document.getElementById('heatmap');
-    // 如果当前页面没有此容器，则终止脚本，避免报错
-    if (!chartDom) return;
+<section class="post-heatmap" aria-labelledby="post-heatmap-title">
+  <div class="post-heatmap__header">
+    <h3 id="post-heatmap-title" class="post-heatmap__title">最近一年文章热力图</h3>
+    <p class="post-heatmap__summary">博文：{{ $postCount }} 篇 | 累计字数：{{ $totalWan }} 万字</p>
+  </div>
 
-    // --- 主题适配 ---
-    // 判断当前主题是亮色还是暗色
-    var isLightTheme = document.body.getAttribute('theme') === 'light';
-    var myChart = echarts.init(chartDom, isLightTheme ? 'light' : 'dark');
-    var textColor = isLightTheme ? '#666' : '#ccc';
-    
-    // 监听窗口大小变化，使图表自适应
-    window.onresize = function() {
-      myChart.resize();
-    };
+  <div class="post-heatmap__body" aria-label="最近一年文章发布热力图">
+    <div class="post-heatmap__days" aria-hidden="true">
+      <span>日</span>
+      <span>一</span>
+      <span>二</span>
+      <span>三</span>
+      <span>四</span>
+      <span>五</span>
+      <span>六</span>
+    </div>
 
-    // --- 数据准备 (由 Hugo 模板在网站构建时动态生成) ---
-    // 创建一个 Map 来存储文章数据，键为 "YYYY-MM-DD" 格式的日期
-    var dataMap = new Map();
-    {{- range .Site.RegularPages -}}
-      {{- if eq .Section "posts" -}}
-        var key = {{ .Date.Format "2006-01-02" }};
-        var value = dataMap.get(key);
-        // 【优化】直接输出数字(单位:千字)，避免因语言环境(如小数点变逗号)导致 NaN 问题
-        var wordCount = {{ div .WordCount 1000.0 }}; 
-        var link = {{ .RelPermalink }};
-        var title = {{ .Title }};
-      
-        // 如果当天已有多篇文章，只保留字数最多的那一篇
-        // 【修正】修正了 value[0] 的错误判断逻辑
-        if (value == null || wordCount > value.wordCount) {
-          dataMap.set(key, {wordCount, link, title});
-        }
+    <div class="post-heatmap__grid">
+      {{- range seq 1 $startWeekday -}}
+        <span class="post-heatmap__cell post-heatmap__cell--empty" aria-hidden="true"></span>
       {{- end -}}
-    {{- end -}}
 
-    // 将 Map 中的数据转换为 ECharts 热力图需要的 [日期, 值] 数组格式
-    var data = [];
-    for (const [key, value] of dataMap.entries()) {
-      data.push([key, value.wordCount]);
+      {{- range $i := seq 0 365 -}}
+        {{- $date := $start.AddDate 0 0 $i -}}
+        {{- $dateKey := $date.Format "2006-01-02" -}}
+        {{- $dayData := index $days $dateKey -}}
+        {{- $words := 0 -}}
+        {{- $count := 0 -}}
+        {{- $level := 0 -}}
+        {{- $label := printf "%s：无文章" ($date.Format "2006-01-02") -}}
+        {{- $link := "" -}}
+        {{- if $dayData -}}
+          {{- $words = $dayData.words -}}
+          {{- $count = $dayData.count -}}
+          {{- $link = $dayData.primaryLink -}}
+          {{- $titles := delimit $dayData.titles "、" -}}
+          {{- $label = printf "%s：%d 篇，约 %.1f 千字｜%s" ($date.Format "2006-01-02") $count (div $words 1000.0) $titles -}}
+          {{- if ge $words 8000 -}}
+            {{- $level = 4 -}}
+          {{- else if ge $words 4000 -}}
+            {{- $level = 3 -}}
+          {{- else if ge $words 1500 -}}
+            {{- $level = 2 -}}
+          {{- else -}}
+            {{- $level = 1 -}}
+          {{- end -}}
+        {{- end -}}
+        {{- if $link -}}
+          <a class="post-heatmap__cell" data-level="{{ $level }}" href="{{ $link }}" title="{{ $label }}" aria-label="{{ $label }}"></a>
+        {{- else -}}
+          <span class="post-heatmap__cell" data-level="{{ $level }}" title="{{ $label }}" aria-label="{{ $label }}"></span>
+        {{- end -}}
+      {{- end -}}
+    </div>
+  </div>
+
+  <div class="post-heatmap__legend" aria-hidden="true">
+    <span>少</span>
+    <span class="post-heatmap__cell" data-level="0"></span>
+    <span class="post-heatmap__cell" data-level="1"></span>
+    <span class="post-heatmap__cell" data-level="2"></span>
+    <span class="post-heatmap__cell" data-level="3"></span>
+    <span class="post-heatmap__cell" data-level="4"></span>
+    <span>多</span>
+  </div>
+</section>
+
+<style>
+  .post-heatmap {
+    --heatmap-cell: 10px;
+    --heatmap-gap: 3px;
+    --heatmap-empty: rgba(122, 168, 116, 0.12);
+    --heatmap-border: rgba(122, 168, 116, 0.22);
+    --heatmap-level-1: rgba(122, 168, 116, 0.32);
+    --heatmap-level-2: rgba(122, 168, 116, 0.52);
+    --heatmap-level-3: rgba(122, 168, 116, 0.74);
+    --heatmap-level-4: #7aa874;
+    --heatmap-text: rgba(102, 102, 102, 0.9);
+    max-width: 660px;
+    margin: 0.75rem auto 1.5rem;
+    padding: 0.8rem 0.9rem;
+    border: 1px solid var(--heatmap-border);
+    border-radius: 14px;
+    background: rgba(122, 168, 116, 0.035);
+  }
+
+  body[theme="dark"] .post-heatmap,
+  body[theme="black"] .post-heatmap {
+    --heatmap-empty: rgba(122, 168, 116, 0.16);
+    --heatmap-border: rgba(122, 168, 116, 0.28);
+    --heatmap-level-1: rgba(122, 168, 116, 0.38);
+    --heatmap-level-2: rgba(122, 168, 116, 0.58);
+    --heatmap-level-3: rgba(122, 168, 116, 0.8);
+    --heatmap-text: rgba(204, 204, 204, 0.9);
+    background: rgba(122, 168, 116, 0.06);
+  }
+
+  .post-heatmap__header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.65rem;
+  }
+
+  .post-heatmap__title,
+  .post-heatmap__summary {
+    margin: 0;
+    color: var(--heatmap-text);
+    line-height: 1.4;
+  }
+
+  .post-heatmap__title {
+    font-size: 0.95rem;
+    font-weight: 600;
+  }
+
+  .post-heatmap__summary {
+    font-size: 0.78rem;
+  }
+
+  .post-heatmap__body {
+    display: flex;
+    gap: 0.45rem;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-bottom: 0.15rem;
+    scrollbar-width: thin;
+  }
+
+  .post-heatmap__days,
+  .post-heatmap__grid {
+    display: grid;
+    grid-template-rows: repeat(7, var(--heatmap-cell));
+    grid-auto-flow: column;
+    gap: var(--heatmap-gap);
+  }
+
+  .post-heatmap__days {
+    flex: 0 0 auto;
+    color: var(--heatmap-text);
+    font-size: 0.62rem;
+    line-height: var(--heatmap-cell);
+    text-align: center;
+  }
+
+  .post-heatmap__grid {
+    grid-auto-columns: var(--heatmap-cell);
+    min-width: max-content;
+  }
+
+  .post-heatmap__cell {
+    display: block;
+    width: var(--heatmap-cell);
+    height: var(--heatmap-cell);
+    border: 1px solid var(--heatmap-border);
+    border-radius: 3px;
+    background: var(--heatmap-empty);
+  }
+
+  a.post-heatmap__cell {
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+  }
+
+  a.post-heatmap__cell:hover,
+  a.post-heatmap__cell:focus {
+    transform: scale(1.25);
+    box-shadow: 0 0 0 2px rgba(122, 168, 116, 0.22);
+    outline: none;
+  }
+
+  .post-heatmap__cell--empty {
+    visibility: hidden;
+  }
+
+  .post-heatmap__cell[data-level="1"] { background: var(--heatmap-level-1); }
+  .post-heatmap__cell[data-level="2"] { background: var(--heatmap-level-2); }
+  .post-heatmap__cell[data-level="3"] { background: var(--heatmap-level-3); }
+  .post-heatmap__cell[data-level="4"] { background: var(--heatmap-level-4); }
+
+  .post-heatmap__legend {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.25rem;
+    margin-top: 0.55rem;
+    color: var(--heatmap-text);
+    font-size: 0.68rem;
+  }
+
+  .post-heatmap__legend .post-heatmap__cell {
+    flex: 0 0 auto;
+  }
+
+  @media (max-width: 600px) {
+    .post-heatmap {
+      --heatmap-cell: 9px;
+      max-width: 100%;
+      padding: 0.7rem;
     }
-    
-    // --- 动态计算总结信息与颜色映射最大值 ---
-    var postCount = dataMap.size;
-    var totalWordCountInThousands = 0;
-    // 【新增】初始化最大字数变量
-    var maxWordCount = 0; 
 
-    // 遍历 dataMap，在累加总字数的同时，找出单篇最大字数
-    for (const value of dataMap.values()) {
-      var currentWordCount = parseFloat(value.wordCount) || 0;
-      totalWordCountInThousands += currentWordCount;
-      
-      // 【新增】如果当前文章字数更大，则更新最大值
-      if (currentWordCount > maxWordCount) {
-        maxWordCount = currentWordCount;
-      }
+    .post-heatmap__header {
+      display: block;
     }
 
-    // 【新增】将最大值向上取整，让图例的颜色刻度更美观 (例如 8.2 会变成 9)
-    var visualMapMax = Math.ceil(maxWordCount);
-
-    var totalWordCountInTenThousands = (totalWordCountInThousands / 10).toFixed(1);
-    var summaryText = '博文：' + postCount + ' 篇 | 累计字数：' + totalWordCountInTenThousands + ' 万字';
-
-    // 根据窗口宽度动态调整热力图显示的时间范围
-    function heatmap_width(months){             
-      var startDate = new Date();
-      var mill = startDate.setMonth((startDate.getMonth() - months));
-      var endDate = +new Date();
-      startDate = +new Date(mill);
-      endDate = echarts.format.formatTime('yyyy-MM-dd', endDate);
-      startDate = echarts.format.formatTime('yyyy-MM-dd', startDate);
-      var showmonth = [];
-      showmonth.push([
-          startDate,
-          endDate
-      ]);
-      return showmonth
-    };
-    function getRangeArr() {
-      const windowWidth = window.innerWidth;
-      if (windowWidth >= 600) {
-        return heatmap_width(12);
-      } else if (windowWidth >= 400) {
-        return heatmap_width(9);
-      } else {
-        return heatmap_width(6);
-      }
+    .post-heatmap__summary {
+      margin-top: 0.15rem;
     }
-
-    // --- ECharts 核心配置 ---
-    var option = {
-      // 背景色设为透明以融入页面
-      backgroundColor: 'transparent',
-
-      // 【修改】标题(title)已被移除
-
-      // 鼠标悬浮时的提示框
-      tooltip: {
-        formatter: function (p) {
-          const post = dataMap.get(p.data[0]);
-          // 在提示框中将字数（单位:千字）格式化为一位小数
-          return p.data[0] + ' | ' + post.title + ' | ' + post.wordCount.toFixed(1) + ' 千字';
-        }
-      },
-
-      // 视觉映射组件，用于根据数值大小映射颜色
-      visualMap: {
-        // 【修改】图例(legend)已被隐藏
-        show: false,
-        min: 0,
-        max: visualMapMax, // 可根据您单篇最长文章的字数（千字）来适当调整
-        type: 'piecewise',
-        inRange: { 
-          color: ['#7aa8744c', '#7AA874' ] 
-        },
-      },
-      
-      // 【新增】图形元素组件，用于在左下角显示总结信息
-      graphic: {
-          type: 'text',     // 元素类型：文本
-          left: 20,         // 定位：距离图表左侧 20px
-          bottom: 5,        // 定位：距离图表底部 5px
-          style: {
-              text: summaryText,     // 绑定的文本内容
-              textAlign: 'left',
-              fill: textColor,       // 文本颜色（已做主题适配）
-              fontSize: 12
-          }
-      },
-
-      // 日历坐标系配置
-      calendar: {
-        // 【修改】调整了上下边距，为移除的标题和新增的说明文字优化布局
-        top: 20,
-        bottom: 30, // 为底部的说明文字留出空间
-        left: 20,
-        right: 4,
-        cellSize: ['auto', 12],
-        range: getRangeArr(),
-        itemStyle: {
-            color: '#F1F1F100', // 背景方块颜色
-            borderWidth: 0.3,
-        },
-        yearLabel: { show: false },
-        monthLabel: { fontSize: 10 },
-        dayLabel: { fontSize: 10 },
-        splitLine: {
-          show: true,
-          lineStyle: {
-            width: 0.5,
-            type: 'dashed'
-          }
-        }
-      },
-
-      // 热力图系列配置
-      series: {
-        type: 'heatmap',
-        coordinateSystem: 'calendar',
-        data: data,
-      }
-    };
-
-    // 将配置项设置到图表实例中
-    myChart.setOption(option);
-
-    // --- 图表交互事件 ---
-    // 点击热力图方块时，在新标签页打开对应的文章链接
-    myChart.on('click', function(params) {
-      if (params.componentType === 'series') {
-        const post = dataMap.get(params.data[0]);
-        if (post && post.link) {
-          const link = window.location.origin + post.link;
-          window.open(link, '_blank').focus();
-        }
-      }
-    });
-
-  });
-</script>
+  }
+</style>


### PR DESCRIPTION
### Motivation

- Replace heavy client-side ECharts implementation with a server-side (Hugo) generated heatmap to remove the JS dependency and avoid runtime parsing issues. 
- Fix aggregation logic and improve accessibility, theming, and responsiveness of the post activity visualization.

### Description

- Removed the ECharts-based `#heatmap` container and all client-side JS and replaced it with a Hugo template that aggregates posts using a `scratch` map and computes per-day counts, total words, and a primary post link. 
- Rendered a 365-day grid of cells (one year) at build time with per-cell `data-level`, `title`, `aria-label`, and anchor behavior for days with posts, and empty/sentinel cells for alignment. 
- Added a header summary showing total post count and total words in 10k units, and a legend; implemented accessible attributes and responsive layout. 
- Introduced comprehensive CSS scoped to `.post-heatmap` to handle theming (light/dark), sizing, hover/focus states, and mobile layout; removed runtime chart resizing, tooltips, and visualMap logic. 

### Testing

- Built the site with `hugo` to verify template rendering and inspected the generated page containing the new heatmap; the site build completed successfully and the heatmap rendered as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff8d83b65c8321b72ea2c26da2e371)