### PR TITLE
Update taxonomy displays for categories, tags and series

### DIFF
--- a/themes/aether/assets/css/_partial/_archive/_tags.scss
+++ b/themes/aether/assets/css/_partial/_archive/_tags.scss
@@ -10,6 +10,15 @@
     @include overflow-wrap(break-word);
     @include transition(all ease-out 0.3s);
 
+    &.tag-cloud-tag-medium {
+      font-size: 0.9em;
+    }
+
+    &.tag-cloud-tag-small {
+      font-size: 0.82em;
+      opacity: 0.82;
+    }
+
     &:active,
     &:focus,
     &:hover {

--- a/themes/aether/assets/css/_partial/_single/_footer.scss
+++ b/themes/aether/assets/css/_partial/_single/_footer.scss
@@ -66,8 +66,15 @@
     font-size: 0.9rem;
   }
 
-  .post-tags {
+  .post-taxonomies {
     max-width: 65%;
+
+    .post-categories,
+    .post-series,
+    .post-tags,
+    .taxonomy-separator {
+      display: inline;
+    }
 
     * {
       display: inline;

--- a/themes/aether/layouts/partials/single/footer.html
+++ b/themes/aether/layouts/partials/single/footer.html
@@ -46,14 +46,38 @@
     </div>
 
     <div class="post-info-more">
-        <section class="post-tags">
+        <section class="post-taxonomies">
+            {{- with .Params.categories -}}
+                <span class="post-categories">
+                    <i class="far fa-folder fa-fw"></i>&nbsp;
+                    {{- range $index, $value := . -}}
+                        {{- if gt $index 0 }},&nbsp;{{ end -}}
+                        {{- $category := partialCached "function/path.html" $value $value | printf "/categories/%v" | $.Site.GetPage -}}
+                        <a href="{{ $category.RelPermalink }}">{{ $category.Title }}</a>
+                    {{- end -}}
+                </span>
+            {{- end -}}
+            {{- with .Params.series -}}
+                {{- with $.Params.categories -}}<span class="taxonomy-separator">&nbsp;·&nbsp;</span>{{- end -}}
+                <span class="post-series">
+                    <i class="far fa-list-alt fa-fw"></i>&nbsp;
+                    {{- range $index, $value := . -}}
+                        {{- if gt $index 0 }},&nbsp;{{ end -}}
+                        {{- $singleSeries := partialCached "function/path.html" $value $value | printf "/series/%v" | $.Site.GetPage -}}
+                        <a href="{{ $singleSeries.RelPermalink }}">{{ $singleSeries.Title }}</a>
+                    {{- end -}}
+                </span>
+            {{- end -}}
             {{- with .Params.tags -}}
-                <i class="fas fa-tags fa-fw"></i>&nbsp;
-                {{- range $index, $value := . -}}
-                    {{- if gt $index 0 }},&nbsp;{{ end -}}
-                    {{- $tag := partialCached "function/path.html" $value $value | printf "/tags/%v" | $.Site.GetPage -}}
-                    <a href="{{ $tag.RelPermalink }}">{{ $tag.Title }}</a>
-                {{- end -}}
+                {{- with (or $.Params.categories $.Params.series) -}}<span class="taxonomy-separator">&nbsp;·&nbsp;</span>{{- end -}}
+                <span class="post-tags">
+                    <i class="fas fa-tags fa-fw"></i>&nbsp;
+                    {{- range $index, $value := . -}}
+                        {{- if gt $index 0 }},&nbsp;{{ end -}}
+                        {{- $tag := partialCached "function/path.html" $value $value | printf "/tags/%v" | $.Site.GetPage -}}
+                        <a href="{{ $tag.RelPermalink }}">{{ $tag.Title }}</a>
+                    {{- end -}}
+                </span>
             {{- end -}}
         </section>
         <section>

--- a/themes/aether/layouts/taxonomy/terms.html
+++ b/themes/aether/layouts/taxonomy/terms.html
@@ -51,13 +51,13 @@
             <div class="series-card">
                 {{- range $terms -}}
                     {{- $term := .Term -}}
-                    {{- $pages := .Pages -}}
+                    {{- $pages := sort .Pages "Date" "asc" -}}
                     {{- with $.Site.GetPage "taxonomy" (printf "%v/%v" $type $term) -}}
                     <div class="card-item">
                         <div class="card-item-wrapper">
                             <h3 class="card-item-title">
                                 <a href="{{ .RelPermalink }}">
-                                    <i class="far fa-folder fa-fw"></i>&nbsp;{{ .Page.Title }}
+                                    <i class="far fa-list-alt fa-fw"></i>&nbsp;{{ .Page.Title }}
                                 </a>
                             </h3>
                             {{- range first 5 $pages -}}
@@ -115,7 +115,13 @@
         {{- else if eq $taxonomies "tags" -}}
             <div class="tag-cloud-tags">
                 {{- range $.Site.Taxonomies.tags.ByCount -}}
-                    <a href="{{ .Page.RelPermalink }}">{{ .Page.Title }} <sup>{{ .Count }}</sup></a>
+                    {{- $class := "tag-cloud-tag" -}}
+                    {{- if eq .Count 1 -}}
+                        {{- $class = printf "%s %s" $class "tag-cloud-tag-small" -}}
+                    {{- else if eq .Count 2 -}}
+                        {{- $class = printf "%s %s" $class "tag-cloud-tag-medium" -}}
+                    {{- end -}}
+                    <a class="{{ $class }}" href="{{ .Page.RelPermalink }}">{{ .Page.Title }} <sup>{{ .Count }}</sup></a>
                 {{- end -}}
             </div>
         {{- end -}}


### PR DESCRIPTION
### Motivation
- Adapt the single-post footer and taxonomy pages to support explicit `categories` and `series` taxonomies alongside existing `tags`, with clear icons and links for each type.
- Make series listings easier to read in canonical order by exposing chronological/weight ordering on series pages.
- Reduce visual noise on the tag cloud by downscaling low-frequency tags while preserving full tag metadata from front matter (no template-level truncation).

### Description
- Added a unified taxonomy block to the single-post footer at `themes/aether/layouts/partials/single/footer.html` that renders `.Params.categories`, `.Params.series` and `.Params.tags` with icons and links to `/categories/{term}/` and `/series/{term}/`, and keeps tags fully rendered from Front Matter.
- Updated footer stylesheet `themes/aether/assets/css/_partial/_single/_footer.scss` to add `.post-taxonomies` layout, inline separators, and styling for the new taxonomy elements.
- Modified `themes/aether/layouts/taxonomy/terms.html` to sort series entries with `sort .Pages "Date" "asc"` and use a list-style icon for series card titles, and to attach frequency-based classes to tag links in the tags branch.
- Extended tag cloud styles in `themes/aether/assets/css/_partial/_archive/_tags.scss` to add `.tag-cloud-tag-medium` and `.tag-cloud-tag-small` with reduced font-size/opacity for low-frequency tags.

### Testing
- Built the site locally with Hugo using `/tmp/hugo-0.123.7/hugo --gc --minify` and the build finished successfully with only deprecation warnings about `author` keys.
- Verified generated landing pages exist and contain expected markup by checking `public/categories/index.html`, `public/tags/index.html`, and `public/series/index.html` and grepping for taxonomy links and classes with `rg` (checks succeeded).
- Captured full-page screenshots of a post footer and the series index using Playwright to visually confirm layout, and the screenshots were generated successfully.
- Ran static checks (`git diff --check`) and local grep-based assertions for the presence of `post-taxonomies`, `/categories/`, `/tags/`, `/series/`, `series-card`, `tag-cloud-tag-small`, and `tag-cloud-tag-medium`, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffef42538483219cda1f441d972701)