### PR TITLE
Add WeChat & CopyLink sharing, improve share UI and i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ hugo new content/posts/2026/20260509.md
 - `params.page.lightgallery = false`：删除 `themes/aether/assets/lib/lightgallery/` 以及仅供 LightGallery 使用的 `themes/aether/static/lib/fonts/`；
 - `params.cookieconsent.enable = false`：删除 `themes/aether/assets/lib/cookieconsent/`。
 
-Simple Icons 也按当前配置裁剪：`[params.social]` 只启用 Email、GitHub、Mastodon、RSS、Telegram，`[params.page.share]` 只启用 Evernote、Pocket、Reddit、Twitter、Weibo，因此不会触发 `Line`、`Instapaper`、`Myspace`、`Baidu` 或任何 `icon.Simpleicons` 社交图标，完整 `themes/aether/assets/lib/simple-icons/` 不再提交。后续若重新启用依赖 Simple Icons 的分享/社交项，不要直接提交完整上游仓库；请先准备一个 simple-icons 的 `icons/` 来源目录，再运行：
+Simple Icons 也按当前配置裁剪：`[params.social]` 只启用 Email、GitHub、Mastodon、RSS、Telegram，`[params.page.share]` 只启用 Twitter、Weibo、Wechat、CopyLink，因此不会触发 `Line`、`Instapaper`、`Myspace`、`Baidu` 或任何 `icon.Simpleicons` 社交图标，完整 `themes/aether/assets/lib/simple-icons/` 不再提交。后续若重新启用依赖 Simple Icons 的分享/社交项，不要直接提交完整上游仓库；请先准备一个 simple-icons 的 `icons/` 来源目录，再运行：
 
 ```bash
 python3 scripts/audit-theme-libs.py --sync-simple-icons --simple-icons-source /path/to/simple-icons/icons --check-simple-icons

--- a/config.toml
+++ b/config.toml
@@ -206,11 +206,10 @@ mhchem = true
 
 [params.page.share]
 enable = true
-Evernote = true
-Pocket = true
-Reddit = true
 Twitter = true
 Weibo = true
+Wechat = true
+CopyLink = true
 
 [params.page.comment]
 enable = true

--- a/themes/aether/assets/css/_partial/_single/_footer.scss
+++ b/themes/aether/assets/css/_partial/_single/_footer.scss
@@ -52,8 +52,134 @@
       }
 
       .post-info-share {
+        > span {
+          display: inline-flex;
+          flex-wrap: wrap;
+          gap: 0.35rem;
+          justify-content: flex-end;
+          align-items: center;
+        }
+
+        a,
+        .share-link {
+          position: relative;
+          display: inline-flex;
+          align-items: center;
+          gap: 0.25rem;
+          min-height: 1.8rem;
+          padding: 0.2rem 0.55rem;
+          border: 1px solid rgba($global-border-color, 0.9);
+          border-radius: 999px;
+          background: rgba(#ffffff, 0.45);
+          color: $global-font-secondary-color;
+          line-height: 1.2;
+          text-decoration: none;
+          cursor: pointer;
+          transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+
+          [theme=dark] & {
+            border-color: rgba($global-border-color-dark, 0.95);
+            background: rgba(#ffffff, 0.04);
+            color: $global-font-secondary-color-dark;
+          }
+
+          [theme=black] & {
+            border-color: rgba($global-border-color-black, 0.95);
+            background: rgba(#ffffff, 0.06);
+            color: $global-font-secondary-color-black;
+          }
+
+          &:hover,
+          &:focus-visible {
+            color: $global-link-hover-color;
+            border-color: rgba($global-link-hover-color, 0.55);
+            background: rgba($global-link-hover-color, 0.08);
+            transform: translateY(-1px);
+
+            [theme=dark] &,
+            [theme=black] & {
+              color: $global-link-hover-color-dark;
+              border-color: rgba($global-link-hover-color-dark, 0.35);
+              background: rgba(#ffffff, 0.12);
+            }
+          }
+
+          &:focus-visible {
+            outline: 2px solid rgba($global-link-hover-color, 0.45);
+            outline-offset: 2px;
+          }
+        }
+
         a * {
           vertical-align: text-bottom;
+        }
+
+        .share-link-label {
+          font-size: 0.72rem;
+          line-height: 1;
+        }
+
+        .share-link-wechat {
+          .share-wechat-panel {
+            position: absolute;
+            right: 0;
+            bottom: calc(100% + 0.6rem);
+            z-index: 10;
+            display: flex;
+            width: 12.5rem;
+            padding: 0.75rem;
+            border: 1px solid $global-border-color;
+            border-radius: 0.75rem;
+            background: $global-background-color;
+            box-shadow: 0 0.75rem 2rem rgba(#000000, 0.14);
+            color: $global-font-secondary-color;
+            text-align: center;
+            opacity: 0;
+            visibility: hidden;
+            pointer-events: none;
+            transform: translateY(0.3rem);
+            transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
+
+            [theme=dark] & {
+              border-color: $global-border-color-dark;
+              background: $global-background-color-dark;
+              color: $global-font-secondary-color-dark;
+            }
+
+            [theme=black] & {
+              border-color: $global-border-color-black;
+              background: $global-background-color-black;
+              color: $global-font-secondary-color-black;
+            }
+          }
+
+          .share-wechat-title {
+            font-size: 0.85rem;
+            font-weight: 600;
+          }
+
+          img {
+            width: 9rem;
+            height: 9rem;
+            padding: 0.35rem;
+            border-radius: 0.35rem;
+            background: #ffffff;
+          }
+
+          .share-wechat-tip {
+            font-size: 0.72rem;
+          }
+
+          &:hover,
+          &:focus,
+          &:focus-within {
+            .share-wechat-panel {
+              opacity: 1;
+              visibility: visible;
+              pointer-events: auto;
+              transform: translateY(0);
+            }
+          }
         }
       }
     }

--- a/themes/aether/i18n/en.toml
+++ b/themes/aether/i18n/en.toml
@@ -112,6 +112,28 @@ other = "Learn more"
 other = "Share on"
 # === partials/plugin/share.html ===
 
+
+[shareWechat]
+other = "WeChat"
+
+[shareWechatTitle]
+other = "Scan with WeChat"
+
+[shareWechatQrAlt]
+other = "WeChat sharing QR code"
+
+[shareWechatTip]
+other = "Or copy the link and open it in WeChat"
+
+[copyArticleLink]
+other = "Copy article link"
+
+[articleLinkCopied]
+other = "Link copied"
+
+[copyLink]
+other = "Copy link"
+
 # === posts/single.html ===
 [contents]
 other = "Contents"
@@ -160,6 +182,7 @@ other = "Home"
 
 [readMore]
 other = "Read more..."
+
 # === posts/single.html ===
 
 # === 404.html ===

--- a/themes/aether/i18n/zh-CN.toml
+++ b/themes/aether/i18n/zh-CN.toml
@@ -119,6 +119,28 @@ other = "了解更多"
 other = "分享到"
 # === partials/plugin/share.html ===
 
+
+[shareWechat]
+other = "微信"
+
+[shareWechatTitle]
+other = "微信扫码分享"
+
+[shareWechatQrAlt]
+other = "微信分享二维码"
+
+[shareWechatTip]
+other = "或复制链接后在微信中打开"
+
+[copyArticleLink]
+other = "复制文章链接"
+
+[articleLinkCopied]
+other = "链接已复制"
+
+[copyLink]
+other = "复制链接"
+
 # === posts/single.html ===
 [contents]
 other = "目录"
@@ -164,6 +186,7 @@ other = "主页"
 
 [readMore]
 other = "阅读全文"
+
 # === posts/single.html ===
 
 # === 404.html ===

--- a/themes/aether/layouts/partials/plugin/share.html
+++ b/themes/aether/layouts/partials/plugin/share.html
@@ -3,8 +3,9 @@
 {{- if $share.enable -}}
     {{- /* 001: Twitter */ -}}
     {{- if $share.Twitter -}}
-        <a href="#" onclick="return false;" title="{{ T `shareOn` }} Twitter" data-sharer="twitter" data-url="{{ .Permalink }}" data-title="{{ .Title }}"{{ with .Site.Params.Social.Twitter }} data-via="{{ . }}"{{ end }}{{ with .Params.tags }} data-hashtags="{{ delimit . `,` }}"{{ end }}>
+        <a class="share-link share-link-twitter" href="#" onclick="return false;" title="{{ T `shareOn` }} Twitter" data-sharer="twitter" data-url="{{ .Permalink }}" data-title="{{ .Title }}"{{ with .Site.Params.Social.Twitter }} data-via="{{ . }}"{{ end }}{{ with .Params.tags }} data-hashtags="{{ delimit . `,` }}"{{ end }}>
             {{- dict "Class" "fab fa-twitter fa-fw" | partial "plugin/icon.html" -}}
+            <span class="share-link-label">Twitter</span>
         </a>
     {{- end -}}
 
@@ -129,8 +130,31 @@
 
     {{- /* 019: 微博 */ -}}
     {{- if $share.Weibo -}}
-        <a href="#" onclick="return false;" title="{{ T `shareOn` }} 微博" data-sharer="weibo" data-url="{{ .Permalink }}" data-title="{{ .Title }}"{{ with .Params.featuredImage }} data-image="{{ . }}"{{ end }}{{ with .Site.Params.Social.Weibo }} data-ralateuid="{{ . }}"{{ end }}>
+        <a class="share-link share-link-weibo" href="#" onclick="return false;" title="{{ T `shareOn` }} 微博" data-sharer="weibo" data-url="{{ .Permalink }}" data-title="{{ .Title }}"{{ with .Params.featuredImage }} data-image="{{ . }}"{{ end }}{{ with .Site.Params.Social.Weibo }} data-ralateuid="{{ . }}"{{ end }}>
             {{- dict "Class" "fab fa-weibo fa-fw" | partial "plugin/icon.html" -}}
+            <span class="share-link-label">微博</span>
+        </a>
+    {{- end -}}
+
+
+    {{- /* 020: 微信 */ -}}
+    {{- if $share.Wechat -}}
+        <span class="share-link share-link-wechat" tabindex="0" role="button" aria-label="{{ T `shareOn` }} 微信" title="{{ T `shareOn` }} 微信">
+            {{- dict "Class" "fab fa-weixin fa-fw" | partial "plugin/icon.html" -}}
+            <span class="share-link-label">{{ T `shareWechat` }}</span>
+            <span class="share-wechat-panel" role="tooltip">
+                <span class="share-wechat-title">{{ T `shareWechatTitle` }}</span>
+                <img src="https://api.qrserver.com/v1/create-qr-code/?size=180x180&amp;margin=10&amp;data={{ .Permalink | urlquery }}" alt="{{ .Title }} {{ T `shareWechatQrAlt` }}" loading="lazy" width="180" height="180">
+                <span class="share-wechat-tip">{{ T `shareWechatTip` }}</span>
+            </span>
+        </span>
+    {{- end -}}
+
+    {{- /* 021: 复制链接 */ -}}
+    {{- if $share.CopyLink -}}
+        <a class="share-link share-link-copy" href="{{ .Permalink }}" title="{{ T `copyArticleLink` }}" aria-label="{{ T `copyArticleLink` }}" data-url="{{ .Permalink }}" data-copy-title="{{ T `copyArticleLink` }}" data-copy-success="{{ T `articleLinkCopied` }}" onclick="if (navigator.clipboard) { navigator.clipboard.writeText(this.dataset.url); this.title = this.dataset.copySuccess; this.setAttribute('aria-label', this.dataset.copySuccess); var icon = this.querySelector('i'); if (icon) { icon.className = 'fas fa-check fa-fw'; } window.setTimeout(() => { this.title = this.dataset.copyTitle; this.setAttribute('aria-label', this.dataset.copyTitle); if (icon) { icon.className = 'fas fa-link fa-fw'; } }, 2000); return false; }">
+            {{- dict "Class" "fas fa-link fa-fw" | partial "plugin/icon.html" -}}
+            <span class="share-link-label">{{ T `copyLink` }}</span>
         </a>
     {{- end -}}
 


### PR DESCRIPTION
### Motivation

- Provide WeChat sharing via QR code and an accessible copy-link action for articles to better support Chinese and mobile workflows.
- Improve the visual style and accessibility of post share controls with compact pill buttons and hover/focus behavior.
- Update configuration and documentation to reflect the trimmed Simple Icons set and the new default enabled share options.

### Description

- Added new share UI styles in `themes/aether/assets/css/_partial/_single/_footer.scss` for pill-like share buttons, WeChat QR panel, and copy-link appearance and interactions.
- Extended the share partial `themes/aether/layouts/partials/plugin/share.html` to include Twitter and Weibo label elements, a WeChat QR share span that generates a QR via an external API, and a `CopyLink` action that uses the Clipboard API with an inline success state update.
- Added localization keys for English and Chinese in `themes/aether/i18n/en.toml` and `themes/aether/i18n/zh-CN.toml` to support WeChat, QR alt/title, copy-link labels, and copy success text.
- Updated `config.toml` to enable `Wechat` and `CopyLink` under `[params.page.share]` and removed previously listed share entries to match the new defaults.
- Updated `README.md` to document the revised default social/share configuration and the Simple Icons trimming guidance.

### Testing

- Built and served the site locally with `hugo server -D` to verify templates and SCSS compile, and the site renders without build errors (success).
- Verified the share partial renders WeChat QR image and the copy-link element in generated HTML by inspecting output pages after the build (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00025b10c483218de7f5edc67b9ccd)