### PR TITLE
Refine article share buttons

### DIFF
--- a/themes/aether/assets/css/_partial/_single/_footer.scss
+++ b/themes/aether/assets/css/_partial/_single/_footer.scss
@@ -52,10 +52,13 @@
       }
 
       .post-info-share {
+        display: flex;
+        justify-content: flex-end;
+
         > span {
           display: inline-flex;
           flex-wrap: wrap;
-          gap: 0.35rem;
+          gap: 0.15rem;
           justify-content: flex-end;
           align-items: center;
         }
@@ -64,48 +67,39 @@
         .share-link {
           position: relative;
           display: inline-flex;
+          justify-content: center;
           align-items: center;
-          gap: 0.25rem;
-          min-height: 1.8rem;
-          padding: 0.2rem 0.55rem;
-          border: 1px solid rgba($global-border-color, 0.9);
-          border-radius: 999px;
-          background: rgba(#ffffff, 0.45);
+          width: 1.8rem;
+          height: 1.8rem;
+          border-radius: 50%;
           color: $global-font-secondary-color;
-          line-height: 1.2;
+          line-height: 1;
           text-decoration: none;
           cursor: pointer;
-          transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+          transition: color 0.2s ease, background 0.2s ease;
 
           [theme=dark] & {
-            border-color: rgba($global-border-color-dark, 0.95);
-            background: rgba(#ffffff, 0.04);
             color: $global-font-secondary-color-dark;
           }
 
           [theme=black] & {
-            border-color: rgba($global-border-color-black, 0.95);
-            background: rgba(#ffffff, 0.06);
             color: $global-font-secondary-color-black;
           }
 
           &:hover,
           &:focus-visible {
-            color: $global-link-hover-color;
-            border-color: rgba($global-link-hover-color, 0.55);
             background: rgba($global-link-hover-color, 0.08);
-            transform: translateY(-1px);
+            color: $global-link-hover-color;
 
             [theme=dark] &,
             [theme=black] & {
+              background: rgba(#ffffff, 0.08);
               color: $global-link-hover-color-dark;
-              border-color: rgba($global-link-hover-color-dark, 0.35);
-              background: rgba(#ffffff, 0.12);
             }
           }
 
           &:focus-visible {
-            outline: 2px solid rgba($global-link-hover-color, 0.45);
+            outline: 2px solid rgba($global-link-hover-color, 0.35);
             outline-offset: 2px;
           }
         }
@@ -115,29 +109,35 @@
         }
 
         .share-link-label {
-          font-size: 0.72rem;
-          line-height: 1;
+          position: absolute;
+          width: 1px;
+          height: 1px;
+          padding: 0;
+          overflow: hidden;
+          clip: rect(0, 0, 0, 0);
+          white-space: nowrap;
+          border: 0;
         }
 
         .share-link-wechat {
           .share-wechat-panel {
             position: absolute;
             right: 0;
-            bottom: calc(100% + 0.6rem);
+            bottom: calc(100% + 0.45rem);
             z-index: 10;
             display: flex;
-            width: 12.5rem;
-            padding: 0.75rem;
+            width: 11rem;
+            padding: 0.65rem;
             border: 1px solid $global-border-color;
-            border-radius: 0.75rem;
+            border-radius: 0.6rem;
             background: $global-background-color;
-            box-shadow: 0 0.75rem 2rem rgba(#000000, 0.14);
+            box-shadow: 0 0.5rem 1.25rem rgba(#000000, 0.08);
             color: $global-font-secondary-color;
             text-align: center;
             opacity: 0;
             visibility: hidden;
             pointer-events: none;
-            transform: translateY(0.3rem);
+            transform: translateY(0.2rem);
             transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
 
             [theme=dark] & {
@@ -154,20 +154,20 @@
           }
 
           .share-wechat-title {
-            font-size: 0.85rem;
+            font-size: 0.8rem;
             font-weight: 600;
           }
 
           img {
-            width: 9rem;
-            height: 9rem;
-            padding: 0.35rem;
+            width: 8rem;
+            height: 8rem;
+            padding: 0.3rem;
             border-radius: 0.35rem;
             background: #ffffff;
           }
 
           .share-wechat-tip {
-            font-size: 0.72rem;
+            font-size: 0.7rem;
           }
 
           &:hover,
@@ -180,6 +180,43 @@
               transform: translateY(0);
             }
           }
+        }
+      }
+    }
+
+    @media only screen and (max-width: 680px) {
+      .post-info-line {
+        align-items: center;
+        gap: 0.75rem;
+      }
+
+      .post-info-line:last-child {
+        align-items: flex-start;
+      }
+
+      .post-info-md {
+        width: auto;
+        min-width: 0;
+      }
+
+      .post-info-share {
+        flex: 1 1 auto;
+        min-width: 0;
+
+        > span {
+          max-width: 100%;
+        }
+
+        a,
+        .share-link {
+          width: 1.65rem;
+          height: 1.65rem;
+          font-size: 0.92rem;
+        }
+
+        .share-link-wechat .share-wechat-panel {
+          right: -0.25rem;
+          width: 10rem;
         }
       }
     }


### PR DESCRIPTION
### Motivation
- Reduce the visual weight and floating feeling of the article share controls so they better match the site aesthetic.
- Make share controls more compact and less obtrusive on mobile screens.
- Preserve accessibility (keep share labels available to screen readers) while hiding visual text.

### Description
- Reworked `.post-info-share` styles in `themes/aether/assets/css/_partial/_single/_footer.scss` to present icon-only circular share buttons and tightened spacing.
- Hid the visible share labels visually but kept them in the DOM for accessibility by converting `.share-link-label` to visually-hidden styles.
- Simplified hover styles by removing pill borders/backgrounds and heavy translate motion, and updated focus outlines for consistency.
- Reduced size, padding, shadow and rounded corners of the WeChat QR popover and added a mobile media-query to further compact share buttons and limit popover width.

### Testing
- Ran `hugo --gc --minify` to build the site successfully.
- Ran `python3 scripts/audit-theme-libs.py --check-simple-icons` which completed and reported no required vendored Simple Icons.
- Ran `git diff --check` which reported no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a000a5077b483219bf6036e13f990be)