### PR TITLE
Allow Vercel dashboard previews via CSP and add troubleshooting note

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,15 @@ hugo --gc --minify
 
 如果 Vercel 项目后台手动开启了 Build Command / Output Directory 的 Override，建议改回与 `vercel.json` 一致，或直接关闭 Override 让仓库配置生效。截图里的 `Command "hugo --gc" exited with 1` 只说明 Hugo 构建失败；真正原因需要展开 Vercel Build Logs 查看具体错误。迁移主题为普通目录后，不需要再在 Vercel 命令里加 `git submodule update --init --recursive`。
 
+### Vercel 后台预览 403 排查
+
+如果站点公网地址（例如 `https://www.philohao.com/`）可以正常打开，但 Vercel Dashboard 的 Deployment 缩略图或预览框显示 `403: Forbidden`，优先按下面顺序处理：
+
+1. 到 **Project Settings → Deployment Protection** 确认 Production/Preview 是否开启了 Vercel Authentication、Password Protection 或 Trusted IPs。后台缩略图会访问生成的 `*.vercel.app` Deployment URL；如果该 URL 被保护，缩略图可能 403，而绑定的自定义域名仍然正常。
+2. 到 **Firewall → Traffic/Events** 查看是否有 DDoS Mitigation、Bot Protection 或自定义规则拦截了 Vercel 的截图/缩略图服务请求。若是系统 DDoS 规则误拦且 Hobby 计划无法添加 System Bypass Rule，需带上 403 页面里的 Request ID 联系 Vercel Support/Abuse 处理。
+3. 本仓库在 `vercel.json` 中显式设置了 `Content-Security-Policy: frame-ancestors 'self' https://vercel.com https://*.vercel.com`，允许 Vercel Dashboard iframe 预览本站，同时仍限制其它第三方站点随意嵌入。
+4. 修改保护/防火墙设置后，重新部署一次；如果新部署能直接访问但 Dashboard 缩略图仍旧显示旧的 403，通常是缩略图缓存，需要等待刷新或联系 Vercel 重新生成预览图。
+
 ## 主题维护说明
 
 - `themes/aether/` 是本站自用主题源码，已经从 Git submodule 迁移为普通目录；主题、内容与配置可以在同一个提交里一起修改和回滚。

--- a/vercel.json
+++ b/vercel.json
@@ -7,5 +7,16 @@
     "env": {
       "HUGO_VERSION": "0.123.7"
     }
-  }
+  },
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "frame-ancestors 'self' https://vercel.com https://*.vercel.com"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
### Motivation

- Vercel Dashboard preview iframe could show `403: Forbidden` even when the public site is reachable, typically due to framing/security or project protection rules. 
- The site should explicitly allow Vercel's preview service to embed the deployment while still restricting other third-party framing. 
- Maintainers need a short troubleshooting guide for common causes (deployment protection, firewall/DDoS rules, cached thumbnails). 

### Description

- Add a `Content-Security-Policy` `frame-ancestors` header in `vercel.json` to allow `https://vercel.com` and `https://*.vercel.com` to embed the site while keeping `self` restriction. 
- Document a concise Vercel Dashboard preview `403` troubleshooting section in `README.md` that explains checking Deployment Protection, Firewall/DDoS mitigation, and thumbnail cache behavior. 
- Modified files: `vercel.json` (add `headers` entry) and `README.md` (add troubleshooting section). 

### Testing

- Validated `vercel.json` is well-formed with `python3 -m json.tool vercel.json`, which succeeded. 
- Built the site locally with `hugo --gc --minify`, which completed successfully. 
- Attempted a remote `curl -I -L` check for the deployment URL but the CI environment returned a `CONNECT tunnel` 403, so remote preview verification could not be completed from this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a004bd1e27c83218f57cece58bb699b)