### PR TITLE
fix: align Vercel build configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,14 @@ hugo --gc --minify
 
 ## Vercel 部署说明
 
-仓库根目录的 `vercel.json` 会固定 Vercel 的 Hugo 构建设置：
+仓库根目录的 `vercel.json` 会固定 Vercel 的 Hugo 构建设置，并应与 Vercel 项目后台保持一致：
 
-- Framework Preset：`hugo`；
+- Framework Preset：`Hugo`（`vercel.json` 中对应 `"framework": "hugo"`）；
 - Build Command：`hugo --gc --minify`；
 - Output Directory：`public`；
-- Hugo 版本：`HUGO_VERSION = 0.123.7`。
+- Hugo 版本：`HUGO_VERSION = 0.123.7`，与本地 `hugo version` 显示的 `v0.123.7` 基线一致。
 
-如果 Vercel 项目后台手动开启了 Build Command / Output Directory 的 Override，建议改回与 `vercel.json` 一致，或直接关闭 Override 让仓库配置生效。截图里的 `Command "hugo --gc" exited with 1` 只说明 Hugo 构建失败；真正原因需要展开 Vercel Build Logs 查看具体错误。迁移主题为普通目录后，不需要再在 Vercel 命令里加 `git submodule update --init --recursive`。
+如果 Vercel 项目后台手动开启了 Framework Preset、Build Command、Output Directory 或环境变量的 Override，建议改回与 `vercel.json` 一致，或直接关闭 Override 让仓库配置生效。Vercel 环境变量中的 `HUGO_VERSION` 也应保持为 `0.123.7`，避免线上构建使用不同 Hugo 版本。截图里的 `Command "hugo --gc" exited with 1` 只说明 Hugo 构建失败；真正原因需要展开 Vercel Build Logs 查看具体错误。迁移主题为普通目录后，不需要再在 Vercel 命令里加 `git submodule update --init --recursive`。
 
 ### Vercel 后台预览 403 排查
 


### PR DESCRIPTION
### Motivation
- 确保仓库内的 Vercel 部署配置与本地 Hugo 基线一致，避免 Vercel 后台的 Framework Preset、Build Command、Output Directory 或 `HUGO_VERSION` 被 override 导致线上构建差异或预览异常。

### Description
- 更新 `README.md` 中的 Vercel 部署说明，明确 `Framework Preset` 为 `Hugo`（对应 `"framework": "hugo"`），要求 `Build Command` 为 `hugo --gc --minify`、`Output Directory` 为 `public`，并强调 `HUGO_VERSION = 0.123.7` 应与本地 `hugo version` 的 `v0.123.7` 保持一致（仅修改文档，`vercel.json` 未改）。

### Testing
- 运行并通过了本地检查与构建：`hugo version`、`hugo --gc --minify`、`rg -n "vercel|Vercel|HUGO_VERSION|buildCommand|outputDirectory|frame-ancestors|Framework Preset|Build Command|Output Directory" README.md vercel.json` 以及 `git diff --check`，均成功。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0055d3813c83219640ceef867d2673)