### PR TITLE
fix: verify comments search and RSS output

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -224,9 +224,13 @@ dataRepoId = "MDEwOlJlcG9zaXRvcnkzNDk5NTUwODc="
 dataCategory = "Comments"
 dataCategoryId = "DIC_kwDOFNvkD84Cvoxi"
 dataMapping = "pathname"
+dataStrict = "0"
 dataReactionsEnabled = "1"
 dataEmitMetadata = "0"
+dataInputPosition = "top"
 dataTheme = "catppuccin_latte"
+dataLang = "zh-CN"
+dataLoading = "lazy"
 
 [params.page.library]
 [params.page.library.css]

--- a/themes/aether/layouts/partials/comment.html
+++ b/themes/aether/layouts/partials/comment.html
@@ -203,26 +203,25 @@
             </noscript>
         {{- end -}}
 
-        {{/* giscus Twikoo Comment System */}}
-        {{- with site.Params.page.comment.giscus -}}
-            {{- if .enable -}}
-                <script src="https://giscus.app/client.js"
-                        data-repo="{{ .dataRepo }}"
-                        data-repo-id="{{ .dataRepoId }}"
-                        data-category="{{ .dataCategory }}"
-                        data-category-id="{{ .dataCategoryId }}"
-                        data-mapping="{{ .dataMapping }}"
-                        data-strict="0"
-                        data-reactions-enabled="{{ .dataReactionsEnabled }}"
-                        data-emit-metadata="{{ .dataEmitMetadata }}"
-                        data-input-position="top"
-                        data-theme="{{ .dataTheme }}"
-                        data-lang="zh-CN"
-                        data-loading="lazy"
-                        crossorigin="anonymous"
-                        async>
-                </script>
-            {{- end -}}
+        {{- /* Giscus Comment System */ -}}
+        {{- $giscus := $comment.giscus | default dict -}}
+        {{- if $giscus.enable -}}
+            <script src="https://giscus.app/client.js"
+                    data-repo="{{ $giscus.dataRepo }}"
+                    data-repo-id="{{ $giscus.dataRepoId }}"
+                    data-category="{{ $giscus.dataCategory }}"
+                    data-category-id="{{ $giscus.dataCategoryId }}"
+                    data-mapping="{{ $giscus.dataMapping | default "pathname" }}"
+                    data-strict="{{ $giscus.dataStrict | default "0" }}"
+                    data-reactions-enabled="{{ $giscus.dataReactionsEnabled | default "1" }}"
+                    data-emit-metadata="{{ $giscus.dataEmitMetadata | default "0" }}"
+                    data-input-position="{{ $giscus.dataInputPosition | default "top" }}"
+                    data-theme="{{ $giscus.dataTheme | default "light" }}"
+                    data-lang="{{ $giscus.dataLang | default .Site.LanguageCode | default "zh-CN" }}"
+                    data-loading="{{ $giscus.dataLoading | default "lazy" }}"
+                    crossorigin="anonymous"
+                    async>
+            </script>
         {{- end -}}
         
         {{- /* Vssue Comment System: local Vssue/Vue assets are not bundled; defaults below use CDN URLs. */ -}}


### PR DESCRIPTION
### Motivation
- Ensure the Giscus comment snippet in the theme matches the site configuration and exposes all script attributes to configuration so the comments partial renders consistently with site `params`.
- Verify local search index generation (`/index.json`) and RSS feed (`/index.xml`) are produced and consumed by the theme without touching unrelated theme/resource cleanup.
- Limit changes to only comments, search index and RSS template/config so builds remain stable per audit workflow.

### Description
- Replace the hard-coded Giscus block in `themes/aether/layouts/partials/comment.html` to read from the rendered page-level comment scratch (`$comment.giscus`) and add safe defaults for attributes such as `data-mapping`, `data-strict`, `data-input-position`, `data-reactions-enabled`, `data-emit-metadata`, `data-theme`, `data-lang` and `data-loading`.
- Add corresponding Giscus parameters in `config.toml` under `[params.page.comment.giscus]` (`dataStrict`, `dataInputPosition`, `dataLang`, `dataLoading`) so template attributes can be configured from the site config.
- No other features, assets or SEO/image/performance items were modified.

### Testing
- Ran `hugo --gc --minify` which completed successfully (build exit 0) and produced `public/index.json` and `public/index.xml`.
- Validated `public/index.json` is valid JSON with records (`index.json ok: 439 records`) and `public/index.xml` is a valid RSS with items (`index.xml ok: 30 items`) using a Python smoke-check script.
- Started local server with `hugo server -D --disableFastRender --bind 127.0.0.1 --port 1313`, fetched `/`, `/posts/`, `/index.json`, `/index.xml` via `curl`, and confirmed sizes and record counts; and inspected generated HTML to confirm the Giscus `<script>` attributes are rendered with configured values.
- Created a single commit with message `fix: verify comments search and RSS output` (commit `168b958`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a005ace14e4832199aeaecac7252e4a)