### PR TITLE
fix: resolve frontend console errors

### DIFF
--- a/themes/aether/layouts/_default/baseof.html
+++ b/themes/aether/layouts/_default/baseof.html
@@ -58,7 +58,7 @@
     {{- /* Load JavaScript scripts and CSS */ -}}
     {{- partial "assets.html" . -}}
 
-    {{ if hugo.IsProduction }}
+    {{ if and hugo.IsProduction (not .Site.IsServer) }}
     <!-- Vercel Analytics -->
     <script defer src="/_vercel/insights/script.js"></script>
     <script defer src="/_vercel/speed-insights/script.js"></script>

--- a/themes/aether/layouts/partials/comment.html
+++ b/themes/aether/layouts/partials/comment.html
@@ -3,7 +3,7 @@
 {{- $comment := .Scratch.Get "comment" | default dict -}}
 {{- $commentConfig := dict -}}
 
-{{- if $comment.enable -}}
+{{- if and $comment.enable (not .Site.IsServer) -}}
     <div id="comments">
         {{- /* Disqus Comment System */ -}}
         {{- $disqus := $comment.disqus | default dict -}}

--- a/themes/aether/layouts/partials/plugin/share.html
+++ b/themes/aether/layouts/partials/plugin/share.html
@@ -139,12 +139,13 @@
 
     {{- /* 020: 微信 */ -}}
     {{- if $share.Wechat -}}
-        <span class="share-link share-link-wechat" tabindex="0" role="button" aria-label="{{ T `shareOn` }} 微信" title="{{ T `shareOn` }} 微信">
+        {{- $wechatQR := printf "https://api.qrserver.com/v1/create-qr-code/?size=180x180&margin=10&data=%s" (.Permalink | urlquery) -}}
+        <span class="share-link share-link-wechat" tabindex="0" role="button" aria-label="{{ T `shareOn` }} 微信" title="{{ T `shareOn` }} 微信" onmouseenter="var img=this.querySelector('img[data-src]'); if (img &amp;&amp; !img.dataset.loaded) { img.src = img.dataset.src; img.dataset.loaded = 'true'; }" onfocus="var img=this.querySelector('img[data-src]'); if (img &amp;&amp; !img.dataset.loaded) { img.src = img.dataset.src; img.dataset.loaded = 'true'; }">
             {{- dict "Class" "fab fa-weixin fa-fw" | partial "plugin/icon.html" -}}
             <span class="share-link-label">{{ T `shareWechat` }}</span>
             <span class="share-wechat-panel" role="tooltip">
                 <span class="share-wechat-title">{{ T `shareWechatTitle` }}</span>
-                <img src="https://api.qrserver.com/v1/create-qr-code/?size=180x180&amp;margin=10&amp;data={{ .Permalink | urlquery }}" alt="{{ .Title }} {{ T `shareWechatQrAlt` }}" loading="lazy" width="180" height="180">
+                <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180' viewBox='0 0 180 180'%3E%3Crect width='180' height='180' fill='%23fff'/%3E%3C/svg%3E" data-src="{{ $wechatQR | safeURL }}" alt="{{ .Title }} {{ T `shareWechatQrAlt` }}" loading="lazy" width="180" height="180">
                 <span class="share-wechat-tip">{{ T `shareWechatTip` }}</span>
             </span>
         </span>


### PR DESCRIPTION
### Motivation
- 避免本地 Hugo server 预览时出现浏览器 Console 红色错误或网络 404，通过有选择地禁止或延迟加载只在生产环境/外部托管时才可用的前端脚本与资源。

### Description
- 在 `themes/aether/layouts/_default/baseof.html` 中将 Vercel Analytics 脚本添加生产且非 `hugo server` 的条件判断 `{{ if and hugo.IsProduction (not .Site.IsServer) }}`，防止本地预览请求 `/_vercel/insights/script.js` 与 `/_vercel/speed-insights/script.js`。
- 在 `themes/aether/layouts/partials/comment.html` 将评论区渲染条件改为 `{{- if and $comment.enable (not .Site.IsServer) -}}`，避免在本地 `hugo server` 预览时加载第三方评论脚本（例如 giscus 等）。
- 在 `themes/aether/layouts/partials/plugin/share.html` 修改微信分享二维码行为：用占位 SVG 作为 `img` 的初始 `src` 并把实际二维码 URL 放到 `data-src`，在 share 控件 `mouseenter`/`focus` 时再把 `data-src` 赋给 `src`，从而延迟第三方二维码请求，消除页面初始加载时的外部资源错误。

### Testing
- 运行 `hugo --gc --minify` 构建站点并确认构建成功，结果为成功。
- 启动本地预览 `hugo server -D --disableFastRender --bind 127.0.0.1 --port 1313` 并确认服务可用，结果为成功。
- 使用自动化检查脚本 `node /tmp/aether-pw/check-console.js` 抽查页面 `/`、示例文章页、归档页、分类页与标签页，报告 Console 红色错误和 404 均为 0，结果为成功。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a005a40a70c8321a90a5b8b81442c73)