### PR TITLE
fix: trim unused theme styles

### DIFF
--- a/themes/aether/assets/css/animate.scss
+++ b/themes/aether/assets/css/animate.scss
@@ -1,0 +1,64 @@
+@charset "utf-8";
+
+// Minimal Animate.css subset used by the theme templates.
+// The site only references animate__animated, animate__faster,
+// animate__pulse, and animate__flipInX, so avoid loading the full
+// animate.css feature bundle on every page.
+.animate__animated {
+  animation-duration: var(--animate-duration, 1s);
+  animation-fill-mode: both;
+}
+
+.animate__faster {
+  animation-duration: calc(var(--animate-duration, 1s) / 2);
+}
+
+.animate__pulse {
+  animation-name: animate-pulse;
+  animation-timing-function: ease-in-out;
+}
+
+.animate__flipInX {
+  animation-name: animate-flip-in-x;
+  backface-visibility: visible !important;
+}
+
+@keyframes animate-pulse {
+  from {
+    transform: scale3d(1, 1, 1);
+  }
+
+  50% {
+    transform: scale3d(1.05, 1.05, 1.05);
+  }
+
+  to {
+    transform: scale3d(1, 1, 1);
+  }
+}
+
+@keyframes animate-flip-in-x {
+  from {
+    transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
+    animation-timing-function: ease-in;
+    opacity: 0;
+  }
+
+  40% {
+    transform: perspective(400px) rotate3d(1, 0, 0, -20deg);
+    animation-timing-function: ease-in;
+  }
+
+  60% {
+    transform: perspective(400px) rotate3d(1, 0, 0, 10deg);
+    opacity: 1;
+  }
+
+  80% {
+    transform: perspective(400px) rotate3d(1, 0, 0, -5deg);
+  }
+
+  to {
+    transform: perspective(400px);
+  }
+}

--- a/themes/aether/layouts/partials/head/link.html
+++ b/themes/aether/layouts/partials/head/link.html
@@ -49,9 +49,10 @@
 {{- $style := dict "Source" $source "Fingerprint" $fingerprint -}}
 {{- partial "plugin/defer-style.html" $style -}}
 
-{{- /* Animate.css */ -}}
-{{- $source := $cdn.animateCSS | default "lib/animate/animate.min.css" -}}
-{{- $style := dict "Source" $source "Fingerprint" $fingerprint -}}
+{{- /* Minimal animation styles used by the theme title templates */ -}}
+{{- $style := dict "Source" "css/animate.scss" "Fingerprint" $fingerprint -}}
+{{- $options := dict "targetPath" "css/animate.min.css" -}}
+{{- $style = dict "Context" . "ToCSS" $options | merge $style -}}
 {{- partial "plugin/defer-style.html" $style -}}
 
 {{- if eq .Site.Params.enablePWA true -}}


### PR DESCRIPTION
### Motivation
- Reduce unnecessary CSS payload by avoiding the full Animate.css bundle which was loaded site-wide. 
- Only keep animation rules that the theme templates actually use (title animations) to speed up page load. 
- Make a minimal change (no large style rewrites) that preserves existing core styles and on-demand feature CSS behavior.

### Description
- Add a minimal animation stylesheet `themes/aether/assets/css/animate.scss` that implements only `animate__animated`, `animate__faster`, `animate__pulse`, `animate__flipInX` and the required `@keyframes`.
- Update `themes/aether/layouts/partials/head/link.html` to compile and load `css/animate.scss` as `css/animate.min.css` instead of including the full `lib/animate/animate.min.css` bundle.
- Preserve existing loading for `css/style.scss`, `normalize.css`, `fontawesome` and conditional feature CSS; no other SCSS sources were removed or rewritten.

### Testing
- Ran a clean site build with `rm -rf public && hugo --gc --minify`, which completed successfully. 
- Verified generated CSS sizes with `find public -type f -name '*.css' -printf '%s %p' | sort -nr | head -20`, confirming `public/css/style.min...css` remains the largest (~114,294 bytes) and the animate bundle is reduced to ~851 bytes instead of ~71 KB. 
- Performed static HTML checks (parsed `public/index.html`, a post page and `public/posts/index.html`) to confirm the pages no longer reference `/lib/animate/` and that `css/style.min.*.css` and the new `css/animate.min.*.css` are present and mobile breakpoint rules exist. 
- Attempted automated browser screenshots with Playwright, but `npx playwright install chromium` failed due to an external download `403 Domain forbidden`, so no headless browser visual checks were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a006a40a6588321835a9844458cb74d)