### PR TITLE
Add fallback /rss.xml and /feed.xml outputs and improve RSS templates

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -339,9 +339,24 @@ isHTML = false
 isPlainText = true
 mediaType = "text/plain"
 
+
+[outputFormats.RSSXML]
+# 保留 Hugo 默认的 /index.xml，同时额外发布 /rss.xml，兼容不会完整执行 HTML 自动发现的阅读器。
+mediaType = "application/rss+xml"
+baseName = "rss"
+isPlainText = false
+notAlternative = true
+
+[outputFormats.FEEDXML]
+# /feed.xml 是另一种常见的阅读器兜底订阅地址。
+mediaType = "application/rss+xml"
+baseName = "feed"
+isPlainText = false
+notAlternative = true
+
 [outputs]
 # JSON 用于本地搜索索引；MarkDown 用于文章页“查看原始 Markdown”。
-home = ["HTML", "RSS", "JSON"]
+home = ["HTML", "RSS", "RSSXML", "FEEDXML", "JSON"]
 page = ["HTML", "MarkDown"]
 section = ["HTML", "RSS"]
 taxonomy = ["HTML", "RSS"]

--- a/layouts/index.feedxml.xml
+++ b/layouts/index.feedxml.xml
@@ -2,13 +2,13 @@
 <rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
     <channel>
         <title>
-            {{- .Params.Title | default (T .Section) | default .Section | dict "Some" | T "allSome" }} - {{ .Site.Title -}}
+            {{- .Site.Title -}}
         </title>
         <link>
             {{- .Permalink -}}
         </link>
         <description>
-            {{- .Params.Title | default (T .Section) | default .Section | dict "Some" | T "allSome" }} | {{ .Site.Title -}}
+            {{- .Site.Params.description | default .Site.Title -}}
         </description>
         <generator>Hugo -- gohugo.io</generator>
         {{- with .Site.LanguageCode -}}
@@ -34,10 +34,10 @@
                 {{- .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" -}}
             </lastBuildDate>
         {{- end -}}
-        {{- with .OutputFormats.Get "RSS" }}
-            {{ printf `<atom:link href=%q rel="self" type=%q />` .Permalink .MediaType | safeHTML }}
-        {{- end }}
-        {{- range .Pages | first (.Site.Params.section.rss | default 10) -}}
+        {{ with .OutputFormats.Get "FEEDXML" }}
+            {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+        {{ end }}
+        {{- range where .Site.RegularPages "Type" "posts" | first (.Site.Params.home.rss | default 10) -}}
             {{- dict "Page" . "Site" .Site | partial "rss/item.html" -}}
         {{- end -}}
     </channel>

--- a/layouts/index.rssxml.xml
+++ b/layouts/index.rssxml.xml
@@ -2,13 +2,13 @@
 <rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
     <channel>
         <title>
-            {{- .Params.Title | default (T .Section) | default .Section | dict "Some" | T "allSome" }} - {{ .Site.Title -}}
+            {{- .Site.Title -}}
         </title>
         <link>
             {{- .Permalink -}}
         </link>
         <description>
-            {{- .Params.Title | default (T .Section) | default .Section | dict "Some" | T "allSome" }} | {{ .Site.Title -}}
+            {{- .Site.Params.description | default .Site.Title -}}
         </description>
         <generator>Hugo -- gohugo.io</generator>
         {{- with .Site.LanguageCode -}}
@@ -34,10 +34,10 @@
                 {{- .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" -}}
             </lastBuildDate>
         {{- end -}}
-        {{- with .OutputFormats.Get "RSS" }}
-            {{ printf `<atom:link href=%q rel="self" type=%q />` .Permalink .MediaType | safeHTML }}
-        {{- end }}
-        {{- range .Pages | first (.Site.Params.section.rss | default 10) -}}
+        {{ with .OutputFormats.Get "RSSXML" }}
+            {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+        {{ end }}
+        {{- range where .Site.RegularPages "Type" "posts" | first (.Site.Params.home.rss | default 10) -}}
             {{- dict "Page" . "Site" .Site | partial "rss/item.html" -}}
         {{- end -}}
     </channel>

--- a/themes/aether/layouts/index.rss.xml
+++ b/themes/aether/layouts/index.rss.xml
@@ -1,3 +1,4 @@
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
     <channel>
         <title>

--- a/themes/aether/layouts/taxonomy/rss.xml
+++ b/themes/aether/layouts/taxonomy/rss.xml
@@ -1,3 +1,4 @@
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
     <channel>
         <title>


### PR DESCRIPTION
### Motivation
- Some external feed readers do not perform HTML auto-discovery of the canonical `/index.xml` and try common addresses like `/rss.xml` or `/feed.xml`, causing missed subscriptions. 
- Improve parser compatibility by adding explicit XML declarations and correct `atom:link rel="self"` for each feed URL.

### Description
- Added two Hugo output formats in `config.toml`: `RSSXML` (baseName `rss`) and `FEEDXML` (baseName `feed`) and included them in the homepage outputs (`home = ["HTML","RSS","RSSXML","FEEDXML","JSON"]`).
- Created root feed templates `layouts/index.rssxml.xml` and `layouts/index.feedxml.xml` that mirror the canonical feed but set their own Atom self links so readers validating `self` see the correct URL. 
- Added XML declaration lines to the theme RSS templates (`themes/aether/layouts/index.rss.xml`, `themes/aether/layouts/posts/rss.xml`, `themes/aether/layouts/taxonomy/rss.xml`) for stricter parser compatibility. 
- Kept existing feed content generation and the `rss/item.html` partial unchanged so feed content and full-text behavior remain as before.

### Testing
- Built the site with `hugo --gc --minify --destination public_test` and the build completed successfully. 
- Parsed the generated feeds with `xml.etree.ElementTree` to ensure well-formed XML and used `feedparser` to validate that each feed is readable, all showed `bozo=False` and expected entry counts. 
- Confirmed each generated root feed contains an `<atom:link ... rel="self" .../>` that points to the corresponding URL (`/index.xml`, `/rss.xml`, `/feed.xml`, `/posts/index.xml`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a014edf577c8321a9a2ec01b83b43c2)