### PR TITLE
Add /rss.xml and /feed.xml outputs and Vercel RSS headers

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -339,9 +339,24 @@ isHTML = false
 isPlainText = true
 mediaType = "text/plain"
 
+
+[outputFormats.RSSXML]
+# 保留 Hugo 默认的 /index.xml，同时额外发布 /rss.xml，兼容不会完整执行 HTML 自动发现的阅读器。
+mediaType = "application/rss+xml"
+baseName = "rss"
+isPlainText = false
+notAlternative = true
+
+[outputFormats.FEEDXML]
+# /feed.xml 是另一种常见的阅读器兜底订阅地址。
+mediaType = "application/rss+xml"
+baseName = "feed"
+isPlainText = false
+notAlternative = true
+
 [outputs]
 # JSON 用于本地搜索索引；MarkDown 用于文章页“查看原始 Markdown”。
-home = ["HTML", "RSS", "JSON"]
+home = ["HTML", "RSS", "RSSXML", "FEEDXML", "JSON"]
 page = ["HTML", "MarkDown"]
 section = ["HTML", "RSS"]
 taxonomy = ["HTML", "RSS"]

--- a/layouts/index.feedxml.xml
+++ b/layouts/index.feedxml.xml
@@ -2,13 +2,13 @@
 <rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
     <channel>
         <title>
-            {{- .Params.Title | default (T .Section) | default .Section | dict "Some" | T "allSome" }} - {{ .Site.Title -}}
+            {{- .Site.Title -}}
         </title>
         <link>
             {{- .Permalink -}}
         </link>
         <description>
-            {{- .Params.Title | default (T .Section) | default .Section | dict "Some" | T "allSome" }} | {{ .Site.Title -}}
+            {{- .Site.Params.description | default .Site.Title -}}
         </description>
         <generator>Hugo -- gohugo.io</generator>
         {{- with .Site.LanguageCode -}}
@@ -34,10 +34,10 @@
                 {{- .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" -}}
             </lastBuildDate>
         {{- end -}}
-        {{- with .OutputFormats.Get "RSS" }}
-            {{ printf `<atom:link href=%q rel="self" type=%q />` .Permalink .MediaType | safeHTML }}
-        {{- end }}
-        {{- range .Pages | first (.Site.Params.section.rss | default 10) -}}
+        {{ with .OutputFormats.Get "FEEDXML" }}
+            {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+        {{ end }}
+        {{- range where .Site.RegularPages "Type" "posts" | first (.Site.Params.home.rss | default 10) -}}
             {{- dict "Page" . "Site" .Site | partial "rss/item.html" -}}
         {{- end -}}
     </channel>

--- a/layouts/index.rssxml.xml
+++ b/layouts/index.rssxml.xml
@@ -2,13 +2,13 @@
 <rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
     <channel>
         <title>
-            {{- .Params.Title | default (T .Section) | default .Section | dict "Some" | T "allSome" }} - {{ .Site.Title -}}
+            {{- .Site.Title -}}
         </title>
         <link>
             {{- .Permalink -}}
         </link>
         <description>
-            {{- .Params.Title | default (T .Section) | default .Section | dict "Some" | T "allSome" }} | {{ .Site.Title -}}
+            {{- .Site.Params.description | default .Site.Title -}}
         </description>
         <generator>Hugo -- gohugo.io</generator>
         {{- with .Site.LanguageCode -}}
@@ -34,10 +34,10 @@
                 {{- .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" -}}
             </lastBuildDate>
         {{- end -}}
-        {{- with .OutputFormats.Get "RSS" }}
-            {{ printf `<atom:link href=%q rel="self" type=%q />` .Permalink .MediaType | safeHTML }}
-        {{- end }}
-        {{- range .Pages | first (.Site.Params.section.rss | default 10) -}}
+        {{ with .OutputFormats.Get "RSSXML" }}
+            {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+        {{ end }}
+        {{- range where .Site.RegularPages "Type" "posts" | first (.Site.Params.home.rss | default 10) -}}
             {{- dict "Page" . "Site" .Site | partial "rss/item.html" -}}
         {{- end -}}
     </channel>

--- a/themes/aether/layouts/index.rss.xml
+++ b/themes/aether/layouts/index.rss.xml
@@ -1,3 +1,4 @@
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
     <channel>
         <title>

--- a/themes/aether/layouts/taxonomy/rss.xml
+++ b/themes/aether/layouts/taxonomy/rss.xml
@@ -1,3 +1,4 @@
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
     <channel>
         <title>

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,64 @@
   },
   "headers": [
     {
+      "source": "/(index|rss|feed).xml",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/rss+xml; charset=utf-8"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400"
+        },
+        {
+          "key": "CDN-Cache-Control",
+          "value": "public, max-age=3600, stale-while-revalidate=86400"
+        },
+        {
+          "key": "Vercel-CDN-Cache-Control",
+          "value": "public, max-age=3600, stale-while-revalidate=86400"
+        },
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
+      ]
+    },
+    {
+      "source": "/(posts|categories|tags|series|authors)/(.*)index.xml",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/rss+xml; charset=utf-8"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400"
+        },
+        {
+          "key": "CDN-Cache-Control",
+          "value": "public, max-age=3600, stale-while-revalidate=86400"
+        },
+        {
+          "key": "Vercel-CDN-Cache-Control",
+          "value": "public, max-age=3600, stale-while-revalidate=86400"
+        },
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
+      ]
+    },
+    {
       "source": "/(.*)",
       "headers": [
         {


### PR DESCRIPTION
### Motivation

- Provide additional RSS endpoints (`/rss.xml` and `/feed.xml`) alongside the default `/index.xml` to improve compatibility with feed readers that don't follow HTML discovery. 
- Ensure generated feed files have proper XML prolog and media types so validators and aggregators accept them. 
- Set correct `Content-Type`, caching and security headers for feed endpoints on Vercel to improve caching behavior and cross-origin access.

### Description

- Added two new output formats in `config.toml`: `RSSXML` and `FEEDXML`, and included them in the `home` outputs as `RSSXML` and `FEEDXML`. 
- Added two new layout templates `layouts/index.rssxml.xml` and `layouts/index.feedxml.xml` to render `/rss.xml` and `/feed.xml`, reusing the existing `rss/item.html` partial for entries. 
- Updated theme templates to include the XML prolog (`<?xml ...?>`) via `safeHTML` so RSS files start with a proper XML declaration. 
- Extended `vercel.json` with headers for `/(index|rss|feed).xml` and for section/taxonomy `index.xml` paths to set `Content-Type: application/rss+xml; charset=utf-8`, cache-control, CORS and `X-Content-Type-Options` security header.

### Testing

- Ran a Hugo build with `hugo --gc --minify`, which completed successfully and produced feed outputs (including `rss.xml` and `feed.xml`). 
- Verified feed templates generate valid XML prolog in the produced RSS files via the build artifacts (automated build assertion), which passed. 
- Validated `vercel.json` structure against the Vercel JSON schema, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a014edf577c8321a9a2ec01b83b43c2)