### PR TITLE
Fix tag explorer filtered card visibility

### DIFF
--- a/themes/aether/assets/css/_partial/_archive/_tags.scss
+++ b/themes/aether/assets/css/_partial/_archive/_tags.scss
@@ -275,6 +275,10 @@
   box-shadow: 0 12px 30px rgba(33, 47, 63, 0.05);
   @include transition(transform ease .2s, box-shadow ease .2s, border-color ease .2s);
 
+  &[hidden] {
+    display: none;
+  }
+
   &:hover {
     border-color: var(--tag-accent);
     box-shadow: var(--tag-shadow);


### PR DESCRIPTION
### Motivation
- The tag explorer sets `hidden` on non-matching `.tag-card` elements but the existing `.tag-card { display: flex; }` styling prevented the browser from removing those cards from layout, so filtering appeared to have no effect.

### Description
- Add an explicit `&[hidden] { display: none; }` rule to `.tag-card` in `themes/aether/assets/css/_partial/_archive/_tags.scss` so cards with the `hidden` attribute are removed from layout.

### Testing
- Ran `hugo --minify` to rebuild assets and the site build completed successfully (no failures related to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02e3c0739c8321a9fa83a8c1ef9155)