### PR TITLE
从 About 页面移除“我的人生版本号”部分

### DIFF
--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -26,9 +26,3 @@ comment = false
 1. 表述明白，把想说的说清楚；
 2. 内容有趣，理性的文章应富有逻辑，感性的文章该满沛情感；
 3. 形式优美一些是极好的。
-
-## 我的人生版本号[^1]
-
-[^1]: PC 端浏览更佳
-
-<iframe id="embed_dom" name="embed_dom" frameborder="0" style="display:block;width:-webkit-fill-available; height:900px;" src="https://www.processon.com/embed/624fd9c30791290727b88c26"></iframe>


### PR DESCRIPTION
### Motivation
- 出于隐私考虑，移除 About 页面中显示的“我的人生版本号”小节及其嵌入内容，避免泄露个人信息。

### Description
- 在 `content/pages/about.md` 中删除了“## 我的人生版本号”标题、相关脚注 `[^1]` 与嵌入的 ProcessOn `<iframe>`，页面正文现在在“我的写作原则”处结束。

### Testing
- 已运行 `git diff --check` 校验文件格式，结果通过。 
- 已运行 `hugo --minify` 构建站点，构建成功。 
- 已启动 `hugo server` 并使用小脚本验证本地页面 HTML 中不再包含 `人生版本号` 与 `processon.com/embed`，校验通过。 
- 已使用 `npx --yes playwright@1.52.0 screenshot ...` 捕获页面截图以确认渲染，截图生成成功。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02edae51d0832190e4811b498599bb)