### PR TITLE
Add Pages CMS configuration for data files

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -1,0 +1,239 @@
+media:
+  input: static/images
+  output: /images
+
+content:
+  - name: data
+    label: Data 数据
+    type: group
+    items:
+      - name: books
+        label: 书刊清单
+        type: file
+        path: data/books.yaml
+        format: yaml
+        list: true
+        fields:
+          - name: title
+            label: 标题
+            type: string
+            required: true
+          - name: coverurl
+            label: 封面 URL
+            type: string
+            description: 可填写 NeoDB、豆瓣、起点或站内图片等完整图片地址。
+          - name: link
+            label: 条目链接
+            type: string
+            description: 作品详情页链接，可留空。
+          - name: author
+            label: 作者
+            type: string
+          - name: type
+            label: 归档月份
+            type: string
+            required: true
+            pattern:
+              regex: "^[0-9]{2}-[0-9]{2}$"
+              message: "请使用 YY-MM 格式，例如 25-09。"
+            description: 页面按此前缀归入年份和月份，格式为 YY-MM。
+          - name: starscore
+            label: 评分星级
+            type: string
+            description: 已点亮星星，例如 ★★★★。
+          - name: greystar
+            label: 灰色星级
+            type: string
+            description: 未点亮星星，可留空，例如 ☆ 或 ☆☆。
+          - name: intro
+            label: 简评
+            type: text
+
+      - name: movies
+        label: 影剧清单
+        type: file
+        path: data/movies.yaml
+        format: yaml
+        list: true
+        fields:
+          - name: title
+            label: 标题
+            type: string
+            required: true
+          - name: coverurl
+            label: 封面 URL
+            type: string
+            description: 可填写 NeoDB、豆瓣、TMDB 或站内图片等完整图片地址。
+          - name: link
+            label: 条目链接
+            type: string
+            description: 作品详情页链接，可留空。
+          - name: author
+            label: 导演 / 主创
+            type: string
+          - name: type
+            label: 归档月份
+            type: string
+            required: true
+            pattern:
+              regex: "^[0-9]{2}-[0-9]{2}$"
+              message: "请使用 YY-MM 格式，例如 25-09。"
+            description: 页面按此前缀归入年份和月份，格式为 YY-MM。
+          - name: starscore
+            label: 评分星级
+            type: string
+            description: 已点亮星星，例如 ★★★★。
+          - name: greystar
+            label: 灰色星级
+            type: string
+            description: 未点亮星星，可留空，例如 ☆ 或 ☆☆。
+          - name: intro
+            label: 简评
+            type: text
+
+      - name: mental_links
+        label: 精神食粮链接
+        type: file
+        path: data/mental_links.yaml
+        format: yaml
+        list: true
+        fields:
+          - name: type
+            label: 归档月份
+            type: string
+            required: true
+            pattern:
+              regex: "^[0-9]{2}-[0-9]{2}$"
+              message: "请使用 YY-MM 格式，例如 25-09。"
+            description: 页面按此前缀归入年份和月份，格式为 YY-MM。
+          - name: category
+            label: 分类
+            type: select
+            required: true
+            options:
+              values:
+                - 自媒体摘录
+                - 文章
+                - 视频
+                - 播客 · 声音发掘
+                - 播客 · 读书分享
+                - 播客 · 技术编程
+                - 播客 · 泛文讲谈
+                - 播客 · 社论观察
+                - 播客 · 商业分析
+                - 播客 · 闲聊讨论
+                - 其他 · RSS/Newsletter
+                - 其他 · Bilibili
+                - 其他 · Youtube
+          - name: title
+            label: 标题
+            type: string
+            required: true
+          - name: url
+            label: 链接
+            type: string
+            required: true
+          - name: source
+            label: 来源 / 作者
+            type: string
+            description: 可留空。
+
+      - name: footprint
+        label: 足迹表格
+        type: file
+        path: data/footprint.yaml
+        format: yaml
+        fields:
+          - name: travel
+            label: 出游
+            type: object
+            fields:
+              - name: "2025"
+                label: 2025 出游
+                component: footprint_year
+              - name: "2024"
+                label: 2024 出游
+                component: footprint_year
+              - name: "2023"
+                label: 2023 出游
+                component: footprint_year
+          - name: reading
+            label: 书影游
+            type: object
+            fields:
+              - name: "2025"
+                label: 2025 书影游
+                component: footprint_year
+              - name: "2024"
+                label: 2024 书影游
+                component: footprint_year
+              - name: "2023"
+                label: 2023 书影游
+                component: footprint_year
+              - name: "2022"
+                label: 2022 书影游
+                component: footprint_year
+          - name: poster
+            label: 海报墙
+            type: object
+            fields:
+              - name: "2025"
+                label: 2025 海报墙
+                component: footprint_year
+              - name: "2024"
+                label: 2024 海报墙
+                component: footprint_year
+              - name: "2023"
+                label: 2023 海报墙
+                component: footprint_year
+
+components:
+  footprint_year:
+    type: object
+    fields:
+      - name: title
+        label: 标题
+        type: string
+        required: true
+      - name: rows
+        label: 月份行
+        type: object
+        list:
+          collapsible:
+            collapsed: true
+            summary: "{month}"
+        fields:
+          - name: month
+            label: 月份
+            type: select
+            required: true
+            options:
+              values:
+                - 一月
+                - 二月
+                - 三月
+                - 四月
+                - 五月
+                - 六月
+                - 七月
+                - 八月
+                - 九月
+                - 十月
+                - 十一月
+                - 十二月
+          - name: events
+            label: 事件
+            type: object
+            list:
+              collapsible:
+                collapsed: true
+                summary: "{city}：{activity}"
+            fields:
+              - name: city
+                label: 城市 / 地点
+                type: string
+                required: true
+              - name: activity
+                label: 活动
+                type: string
+                required: true


### PR DESCRIPTION
### Motivation

- 把本地维护的 `data/*.yaml` 文件纳入 Pages CMS 管理，便于在 Web UI 中编辑书籍、影剧、链接和足迹数据。 
- 提供站内图片上传/选择入口，将 CMS 媒体目录指向站点的 `static/images` 以复用现有静态资源。 
- 根据现有 YAML 结构映射字段与最小校验，保持现有模板（Shortcode/partials）能直接使用 CMS 写入的数据。

### Description

- 新增根配置文件 ` .pages.yml`，在其中将媒体输入配置为 `static/images` 并将输出路径设为 `/images`。 
- 在 `content` 下添加 `data` 分组，分别为 `data/books.yaml`、`data/movies.yaml`、`data/mental_links.yaml`、`data/footprint.yaml` 创建文件型编辑器并定义每条记录的字段（标题、封面、链接、作者、`type`、评分、简介等）。 
- 为 `type` 字段加入格式校验（`regex: "^[0-9]{2}-[0-9]{2}$"`）并为 `mental_links` 的 `category` 提供下拉选项以匹配现有分类。 
- 新增可复用组件 `footprint_year` 用于表达 `footprint.yaml` 中的每年对象（标题、月份行、每月事件的 `city` 与 `activity`）。

### Testing

- 使用 `ruby -ryaml -e 'YAML.load_file(".pages.yml"); Dir["data/*.yaml"].each { |p| YAML.load_file(p, aliases: true) }'` 验证 `.pages.yml` 与仓库中所有 `data/*.yaml` 可被解析，结果成功。 
- 执行 `hugo --minify` 进行站点构建检查，构建完成且仅出现现有配置的弃用警告，未阻塞构建。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07cc639e088321acede568dbfc99a8)