### PR TITLE
Add 2026 footprint pages and support year-keyed mentalfood data

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -1,0 +1,314 @@
+media:
+  input: static/images
+  output: /images
+
+content:
+  - name: data
+    label: Data 数据
+    type: group
+    items:
+      - name: books
+        label: 书刊清单
+        type: file
+        path: data/books.yaml
+        format: yaml
+        fields:
+          - name: "2026"
+            label: 2026 书刊
+            component: book_records
+          - name: "2025"
+            label: 2025 书刊
+            component: book_records
+          - name: "2024"
+            label: 2024 书刊
+            component: book_records
+          - name: "2023"
+            label: 2023 书刊
+            component: book_records
+          - name: "2022"
+            label: 2022 书刊
+            component: book_records
+
+      - name: movies
+        label: 影剧清单
+        type: file
+        path: data/movies.yaml
+        format: yaml
+        fields:
+          - name: "2026"
+            label: 2026 影剧
+            component: movie_records
+          - name: "2025"
+            label: 2025 影剧
+            component: movie_records
+          - name: "2024"
+            label: 2024 影剧
+            component: movie_records
+          - name: "2023"
+            label: 2023 影剧
+            component: movie_records
+          - name: "2022"
+            label: 2022 影剧
+            component: movie_records
+
+      - name: mental_links
+        label: 精神食粮链接
+        type: file
+        path: data/mental_links.yaml
+        format: yaml
+        fields:
+          - name: "2026"
+            label: 2026 链接
+            component: mental_link_records
+          - name: "2025"
+            label: 2025 链接
+            component: mental_link_records
+          - name: "2024"
+            label: 2024 链接
+            component: mental_link_records
+          - name: "2023"
+            label: 2023 链接
+            component: mental_link_records
+          - name: "2022"
+            label: 2022 链接
+            component: mental_link_records
+
+      - name: footprint
+        label: 足迹表格
+        type: file
+        path: data/footprint.yaml
+        format: yaml
+        fields:
+          - name: travel
+            label: 出游
+            type: object
+            fields:
+              - name: "2026"
+                label: 2026 出游
+                component: footprint_year
+              - name: "2025"
+                label: 2025 出游
+                component: footprint_year
+              - name: "2024"
+                label: 2024 出游
+                component: footprint_year
+              - name: "2023"
+                label: 2023 出游
+                component: footprint_year
+          - name: reading
+            label: 书影游
+            type: object
+            fields:
+              - name: "2026"
+                label: 2026 书影游
+                component: footprint_year
+              - name: "2025"
+                label: 2025 书影游
+                component: footprint_year
+              - name: "2024"
+                label: 2024 书影游
+                component: footprint_year
+              - name: "2023"
+                label: 2023 书影游
+                component: footprint_year
+              - name: "2022"
+                label: 2022 书影游
+                component: footprint_year
+          - name: poster
+            label: 海报墙
+            type: object
+            fields:
+              - name: "2026"
+                label: 2026 海报墙
+                component: footprint_year
+              - name: "2025"
+                label: 2025 海报墙
+                component: footprint_year
+              - name: "2024"
+                label: 2024 海报墙
+                component: footprint_year
+              - name: "2023"
+                label: 2023 海报墙
+                component: footprint_year
+
+components:
+  book_records:
+    type: object
+    list:
+      collapsible:
+        collapsed: true
+        summary: "{title} · {type}"
+    fields:
+      - name: title
+        label: 标题
+        type: string
+        required: true
+      - name: coverurl
+        label: 封面 URL
+        type: string
+        description: 可填写 NeoDB、豆瓣、起点或站内图片等完整图片地址。
+      - name: link
+        label: 条目链接
+        type: string
+        description: 作品详情页链接，可留空。
+      - name: author
+        label: 作者
+        type: string
+      - name: type
+        label: 归档月份
+        type: string
+        required: true
+        pattern:
+          regex: "^[0-9]{2}-[0-9]{2}$"
+          message: "请使用 YY-MM 格式，例如 25-09。"
+        description: 页面按此前缀归入年份和月份，格式为 YY-MM。
+      - name: starscore
+        label: 评分星级
+        type: string
+        description: 已点亮星星，例如 ★★★★。
+      - name: greystar
+        label: 灰色星级
+        type: string
+        description: 未点亮星星，可留空，例如 ☆ 或 ☆☆。
+      - name: intro
+        label: 简评
+        type: text
+
+  movie_records:
+    type: object
+    list:
+      collapsible:
+        collapsed: true
+        summary: "{title} · {type}"
+    fields:
+      - name: title
+        label: 标题
+        type: string
+        required: true
+      - name: coverurl
+        label: 封面 URL
+        type: string
+        description: 可填写 NeoDB、豆瓣、TMDB 或站内图片等完整图片地址。
+      - name: link
+        label: 条目链接
+        type: string
+        description: 作品详情页链接，可留空。
+      - name: author
+        label: 导演 / 主创
+        type: string
+      - name: type
+        label: 归档月份
+        type: string
+        required: true
+        pattern:
+          regex: "^[0-9]{2}-[0-9]{2}$"
+          message: "请使用 YY-MM 格式，例如 25-09。"
+        description: 页面按此前缀归入年份和月份，格式为 YY-MM。
+      - name: starscore
+        label: 评分星级
+        type: string
+        description: 已点亮星星，例如 ★★★★。
+      - name: greystar
+        label: 灰色星级
+        type: string
+        description: 未点亮星星，可留空，例如 ☆ 或 ☆☆。
+      - name: intro
+        label: 简评
+        type: text
+
+  mental_link_records:
+    type: object
+    list:
+      collapsible:
+        collapsed: true
+        summary: "{title} · {type}"
+    fields:
+      - name: type
+        label: 归档月份
+        type: string
+        required: true
+        pattern:
+          regex: "^[0-9]{2}-[0-9]{2}$"
+          message: "请使用 YY-MM 格式，例如 25-09。"
+        description: 页面按此前缀归入年份和月份，格式为 YY-MM。
+      - name: category
+        label: 分类
+        type: select
+        required: true
+        options:
+          values:
+            - 自媒体摘录
+            - 文章
+            - 视频
+            - 播客 · 声音发掘
+            - 播客 · 读书分享
+            - 播客 · 技术编程
+            - 播客 · 泛文讲谈
+            - 播客 · 社论观察
+            - 播客 · 商业分析
+            - 播客 · 闲聊讨论
+            - 其他 · RSS/Newsletter
+            - 其他 · Bilibili
+            - 其他 · Youtube
+      - name: title
+        label: 标题
+        type: string
+        required: true
+      - name: url
+        label: 链接
+        type: string
+        required: true
+      - name: source
+        label: 来源 / 作者
+        type: string
+        description: 可留空。
+
+  footprint_year:
+    type: object
+    fields:
+      - name: title
+        label: 标题
+        type: string
+        required: true
+      - name: rows
+        label: 月份行
+        type: object
+        list:
+          collapsible:
+            collapsed: true
+            summary: "{month}"
+        fields:
+          - name: month
+            label: 月份
+            type: select
+            required: true
+            options:
+              values:
+                - 一月
+                - 二月
+                - 三月
+                - 四月
+                - 五月
+                - 六月
+                - 七月
+                - 八月
+                - 九月
+                - 十月
+                - 十一月
+                - 十二月
+          - name: events
+            label: 事件
+            type: object
+            list:
+              collapsible:
+                collapsed: true
+                summary: "{city}：{activity}"
+            fields:
+              - name: city
+                label: 城市 / 地点
+                type: string
+                required: true
+              - name: activity
+                label: 活动
+                type: string
+                required: true

--- a/content/pages/footprint/2026/poster.md
+++ b/content/pages/footprint/2026/poster.md
@@ -1,0 +1,16 @@
++++
+title = "2026 海报墙"
+description = "2026 年海报墙记录占位页。"
+date = "2026-01-01"
+layout = "footprint-year"
+year = 2026
+category = "poster"
+comment = false
+toc = false
+hiddenFromHomePage = true
+hiddenFromSearch = false
++++
+
+## 2026 年
+
+海报墙记录待整理。

--- a/content/pages/footprint/2026/reading.md
+++ b/content/pages/footprint/2026/reading.md
@@ -1,0 +1,16 @@
++++
+title = "2026 书影游"
+description = "2026 年读过的书、看过的影剧和收藏的内容摘录。"
+date = "2026-01-01"
+layout = "footprint-year"
+year = 2026
+category = "reading"
+comment = false
+toc = false
+hiddenFromHomePage = true
+hiddenFromSearch = false
++++
+
+## 2026 年书影游
+
+这一页汇总 2026 年读过的书刊、看过的影剧，以及值得回看的文章、视频和播客摘录。

--- a/content/pages/footprint/2026/travel.md
+++ b/content/pages/footprint/2026/travel.md
@@ -1,0 +1,16 @@
++++
+title = "2026 出游"
+description = "2026 年出游记录、相册和照片流。"
+date = "2026-01-01"
+layout = "footprint-year"
+year = 2026
+category = "travel"
+comment = false
+toc = false
+hiddenFromHomePage = true
+hiddenFromSearch = false
++++
+
+## 2026 年
+
+出游记录待整理。

--- a/content/pages/footprint/_index.md
+++ b/content/pages/footprint/_index.md
@@ -11,6 +11,6 @@ hiddenFromSearch = false
 
 这里按年份与分类收纳出游、书影游和海报墙。
 
-- [进入 2025 出游年度卷宗](/pages/footprint/2025/travel/)
-- [进入 2025 书影游年度清单](/pages/footprint/2025/reading/)
+- [进入 2026 出游年度卷宗](/pages/footprint/2026/travel/)
+- [进入 2026 书影游年度清单](/pages/footprint/2026/reading/)
 - 也可以使用页面上方的年份与分类导航切换。

--- a/data/books.yaml
+++ b/data/books.yaml
@@ -1,4 +1,5 @@
 ---
+'2025':
 - title: 大唐双龙传
   coverurl: https://neodb.social/m/book/2021/09/17dd81c9b9-0e2d-47fe-9b08-30b4c732249f.jpg
   link: https://neodb.social/book/7TpGOqhdp2Q87oZn8wj0xc
@@ -71,6 +72,7 @@
   starscore: "★★★"
   greystar: "☆☆"
   intro: 因为动漫又来重温书，动漫编剧处理完挺好看能有4星，书一般就远古网文水平，胜在变换节奏给人新鲜感保持不错，文笔、人物塑造之类的就不是很好
+'2024':
 - title: 某霍格沃茨的魔文教授
   coverurl: https://bookcover.yuewen.com/qdbimg/349573/1027307054/180.webp
   link: https://book.qidian.com/info/1027307054/
@@ -95,6 +97,7 @@
   starscore: "★★★★"
   greystar: "☆"
   intro: 我，李凡，一介凡人，百世不悔，但求长生！
+'2023':
 - title: 如首无作祟之物
   coverurl: https://neodb.social/m/book/2021/12/106fd29eec-a952-4d03-aab2-8a8b3d3cd69d.jpg
   link: https://neodb.social/book/0qXBfLiJe1zvenn2B0VnJO
@@ -263,6 +266,7 @@
   starscore: "★★★"
   greystar: "☆☆"
   intro: 做这样一块快意恩仇的东林石头，或许是每个少年都曾经有过的最朴素的英雄梦吧。
+'2022':
 - title: "《挽救计划》"
   coverurl: ''
   link: ''

--- a/data/footprint.yaml
+++ b/data/footprint.yaml
@@ -1,4 +1,31 @@
 travel:
+  "2026":
+    title: "2026 出游"
+    rows: &empty_2026
+      - month: "一月"
+        events: []
+      - month: "二月"
+        events: []
+      - month: "三月"
+        events: []
+      - month: "四月"
+        events: []
+      - month: "五月"
+        events: []
+      - month: "六月"
+        events: []
+      - month: "七月"
+        events: []
+      - month: "八月"
+        events: []
+      - month: "九月"
+        events: []
+      - month: "十月"
+        events: []
+      - month: "十一月"
+        events: []
+      - month: "十二月"
+        events: []
   "2025":
     title: "2025 出游"
     rows:
@@ -155,6 +182,9 @@ travel:
           - city: "香港"
             activity: "港岛画恐龙"
 reading:
+  "2026":
+    title: "2026 书影游"
+    rows: *empty_2026
   "2025":
     title: "2025 书影游"
     rows: &empty_2025
@@ -192,6 +222,9 @@ reading:
     title: "2022 书影游"
     rows: *empty_2025
 poster:
+  "2026":
+    title: "2026 海报墙"
+    rows: *empty_2026
   "2025":
     title: "2025 海报墙"
     rows: *empty_2025

--- a/data/mental_links.yaml
+++ b/data/mental_links.yaml
@@ -1,4 +1,5 @@
 ---
+'2025':
 - type: 25-01
   category: 自媒体摘录
   title: "《是，大臣》全片+小说精讲"
@@ -9,6 +10,7 @@
   title: 花5天时间把广州玩了个遍，总结了这份保姆级旅行攻略！
   url: https://www.bilibili.com/video/BV1yzAhetEcs/
   source: 大橘小狸环游记
+'2024':
 - type: 24-01
   category: 自媒体摘录
   title: 关于东亚人适量饮酒与健康的误解
@@ -64,6 +66,7 @@
   title: 全国医院活地图｜各地生病去哪看？值得收藏！
   url: https://www.bilibili.com/video/BV1zRByYbEqd/
   source: 整形医生肖一丁
+'2023':
 - type: 23-00
   category: 文章
   title: 淺談 Atomic CSS 的發展背景與 Tailwind CSS
@@ -84,6 +87,7 @@
   title: CSAPP - 深入理解计算机系统
   url: https://space.bilibili.com/354767108/channel/collectiondetail?sid=373847&ctype=0
   source: ''
+'2022':
 - type: 22-00
   category: 文章
   title: 财新 | 2021 年最具影响力的 21 件事

--- a/data/movies.yaml
+++ b/data/movies.yaml
@@ -1,4 +1,5 @@
 ---
+'2025':
 - title: 嗜血法医 第一季 (2006)
   coverurl: https://neodb.social/m/movie/2021/11/27101089f8-d0e8-4532-b500-3b1a6412617c.jpg
   link: https://neodb.social/tv/season/2GvfGAZ9FdHG3qwhLpNANz
@@ -87,6 +88,7 @@
   starscore: "★★★"
   greystar: "☆☆"
   intro: 警察捉小偷系列，剧情里面张子枫和坏小伙们的身世及转变剧情有点弱。不过基本都是为打戏来看的，剧情不论，打戏干脆利落，梁家辉演技加分。
+'2024':
 - title: 非诚勿扰3 (2023)
   coverurl: https://neodb.social/m/item/doubanmovie/2024/01/23/59332769-2b31-4a75-a2b1-750be4a2cb68.webp
   link: ''
@@ -247,6 +249,7 @@
   starscore: "★★★"
   greystar: "☆☆"
   intro: 剧情高开低走，不过纯看武打就够了，打得热热闹闹的，管它情节合不合理。
+'2023':
 - title: "《弥留之国的爱丽丝 第二季》"
   coverurl: ''
   link: ''
@@ -559,6 +562,7 @@
   starscore: ''
   greystar: ''
   intro: 2023-11-29(英国)
+'2022':
 - title: "《控方证人》"
   coverurl: ''
   link: ''

--- a/layouts/partials/mentalfood/year.html
+++ b/layouts/partials/mentalfood/year.html
@@ -1,23 +1,35 @@
 {{- $year := printf "%v" (.year | default "") -}}
 {{- $shortYear := $year -}}
 {{- if eq (len $year) 4 -}}{{- $shortYear = substr $year 2 2 -}}{{- end -}}
-{{- $booksData := site.Data.books | default slice -}}
-{{- $moviesData := site.Data.movies | default slice -}}
-{{- $linksData := site.Data.mental_links | default slice -}}
+{{- $booksData := site.Data.books | default dict -}}
+{{- $moviesData := site.Data.movies | default dict -}}
+{{- $linksData := site.Data.mental_links | default dict -}}
 {{- $books := slice -}}
 {{- $movies := slice -}}
 {{- $links := slice -}}
-{{- range $booksData -}}
-    {{- $type := printf "%v" (.type | default "") -}}
-    {{- if hasPrefix $type $shortYear -}}{{- $books = $books | append . -}}{{- end -}}
+{{- if reflect.IsMap $booksData -}}
+    {{- $books = index $booksData $year | default slice -}}
+{{- else -}}
+    {{- range $booksData -}}
+        {{- $type := printf "%v" (.type | default "") -}}
+        {{- if hasPrefix $type $shortYear -}}{{- $books = $books | append . -}}{{- end -}}
+    {{- end -}}
 {{- end -}}
-{{- range $moviesData -}}
-    {{- $type := printf "%v" (.type | default "") -}}
-    {{- if hasPrefix $type $shortYear -}}{{- $movies = $movies | append . -}}{{- end -}}
+{{- if reflect.IsMap $moviesData -}}
+    {{- $movies = index $moviesData $year | default slice -}}
+{{- else -}}
+    {{- range $moviesData -}}
+        {{- $type := printf "%v" (.type | default "") -}}
+        {{- if hasPrefix $type $shortYear -}}{{- $movies = $movies | append . -}}{{- end -}}
+    {{- end -}}
 {{- end -}}
-{{- range $linksData -}}
-    {{- $type := printf "%v" (.type | default "") -}}
-    {{- if hasPrefix $type $shortYear -}}{{- $links = $links | append . -}}{{- end -}}
+{{- if reflect.IsMap $linksData -}}
+    {{- $links = index $linksData $year | default slice -}}
+{{- else -}}
+    {{- range $linksData -}}
+        {{- $type := printf "%v" (.type | default "") -}}
+        {{- if hasPrefix $type $shortYear -}}{{- $links = $links | append . -}}{{- end -}}
+    {{- end -}}
 {{- end -}}
 
 <section class="mentalfood-year footprint-reading-year" id="mentalfood-{{ $year }}">

--- a/themes/aether/layouts/shortcodes/mentalfood.html
+++ b/themes/aether/layouts/shortcodes/mentalfood.html
@@ -1,48 +1,74 @@
-{{- $booksData := site.Data.books | default slice -}}
-{{- $moviesData := site.Data.movies | default slice -}}
-{{- $linksData := site.Data.mental_links | default slice -}}
+{{- $booksData := site.Data.books | default dict -}}
+{{- $moviesData := site.Data.movies | default dict -}}
+{{- $linksData := site.Data.mental_links | default dict -}}
 {{- $years := slice -}}
-{{- range $booksData -}}
-    {{- $type := printf "%v" (.type | default "") -}}
-    {{- if ge (len $type) 2 -}}{{- $years = $years | append (substr $type 0 2) -}}{{- end -}}
+{{- if reflect.IsMap $booksData -}}
+    {{- range $year, $_ := $booksData -}}{{- $years = $years | append (printf "%v" $year) -}}{{- end -}}
+{{- else -}}
+    {{- range $booksData -}}
+        {{- $type := printf "%v" (.type | default "") -}}
+        {{- if ge (len $type) 2 -}}{{- $years = $years | append (printf "20%s" (substr $type 0 2)) -}}{{- end -}}
+    {{- end -}}
 {{- end -}}
-{{- range $moviesData -}}
-    {{- $type := printf "%v" (.type | default "") -}}
-    {{- if ge (len $type) 2 -}}{{- $years = $years | append (substr $type 0 2) -}}{{- end -}}
+{{- if reflect.IsMap $moviesData -}}
+    {{- range $year, $_ := $moviesData -}}{{- $years = $years | append (printf "%v" $year) -}}{{- end -}}
+{{- else -}}
+    {{- range $moviesData -}}
+        {{- $type := printf "%v" (.type | default "") -}}
+        {{- if ge (len $type) 2 -}}{{- $years = $years | append (printf "20%s" (substr $type 0 2)) -}}{{- end -}}
+    {{- end -}}
 {{- end -}}
-{{- range $linksData -}}
-    {{- $type := printf "%v" (.type | default "") -}}
-    {{- if ge (len $type) 2 -}}{{- $years = $years | append (substr $type 0 2) -}}{{- end -}}
+{{- if reflect.IsMap $linksData -}}
+    {{- range $year, $_ := $linksData -}}{{- $years = $years | append (printf "%v" $year) -}}{{- end -}}
+{{- else -}}
+    {{- range $linksData -}}
+        {{- $type := printf "%v" (.type | default "") -}}
+        {{- if ge (len $type) 2 -}}{{- $years = $years | append (printf "20%s" (substr $type 0 2)) -}}{{- end -}}
+    {{- end -}}
 {{- end -}}
 {{- $years = sort ($years | uniq) "value" "desc" -}}
 
 <nav class="mentalfood-nav" aria-label="读看听年份导航">
     <span>年份：</span>
     {{- range $years -}}
-        <a href="#mentalfood-20{{ . }}">20{{ . }}</a>
+        <a href="#mentalfood-{{ . }}">{{ . }}</a>
     {{- end -}}
 </nav>
 
 {{- range $index, $year := $years -}}
+    {{- $shortYear := $year -}}
+    {{- if eq (len $year) 4 -}}{{- $shortYear = substr $year 2 2 -}}{{- end -}}
     {{- $books := slice -}}
     {{- $movies := slice -}}
     {{- $links := slice -}}
-    {{- range $booksData -}}
-        {{- $type := printf "%v" (.type | default "") -}}
-        {{- if hasPrefix $type $year -}}{{- $books = $books | append . -}}{{- end -}}
+    {{- if reflect.IsMap $booksData -}}
+        {{- $books = index $booksData $year | default slice -}}
+    {{- else -}}
+        {{- range $booksData -}}
+            {{- $type := printf "%v" (.type | default "") -}}
+            {{- if hasPrefix $type $shortYear -}}{{- $books = $books | append . -}}{{- end -}}
+        {{- end -}}
     {{- end -}}
-    {{- range $moviesData -}}
-        {{- $type := printf "%v" (.type | default "") -}}
-        {{- if hasPrefix $type $year -}}{{- $movies = $movies | append . -}}{{- end -}}
+    {{- if reflect.IsMap $moviesData -}}
+        {{- $movies = index $moviesData $year | default slice -}}
+    {{- else -}}
+        {{- range $moviesData -}}
+            {{- $type := printf "%v" (.type | default "") -}}
+            {{- if hasPrefix $type $shortYear -}}{{- $movies = $movies | append . -}}{{- end -}}
+        {{- end -}}
     {{- end -}}
-    {{- range $linksData -}}
-        {{- $type := printf "%v" (.type | default "") -}}
-        {{- if hasPrefix $type $year -}}{{- $links = $links | append . -}}{{- end -}}
+    {{- if reflect.IsMap $linksData -}}
+        {{- $links = index $linksData $year | default slice -}}
+    {{- else -}}
+        {{- range $linksData -}}
+            {{- $type := printf "%v" (.type | default "") -}}
+            {{- if hasPrefix $type $shortYear -}}{{- $links = $links | append . -}}{{- end -}}
+        {{- end -}}
     {{- end -}}
     {{- $open := eq $index 0 -}}
     {{- if or (gt (len $books) 0) (gt (len $movies) 0) (gt (len $links) 0) -}}
-        <section class="mentalfood-year" id="mentalfood-20{{ $year }}">
-            <h2>20{{ $year }}</h2>
+        <section class="mentalfood-year" id="mentalfood-{{ $year }}">
+            <h2>{{ $year }}</h2>
             <div class="details admonition note{{ if $open }} open{{ end }}">
                 <div class="details-summary admonition-title">
                     <i class="icon fas fa-pencil-alt fa-fw"></i>书刊（{{ len $books }} 本）<i class="details-icon fas fa-angle-right fa-fw"></i>


### PR DESCRIPTION
### Motivation

- Introduce 2026 placeholder pages and seed data for footprint categories (travel, reading, poster) to prepare annual content. 
- Move toward a year-keyed organization for media/links data to make data files keyed by full year strings instead of flat lists with `type` prefixes. 
- Ensure templates and shortcodes can read both the new map-structured data and the legacy list-structured data to remain backward compatible.

### Description

- Add CMS schema file `/.pages.yml` with components and fields for `books`, `movies`, `mental_links`, and `footprint` to drive editing in the CMS. 
- Create new footprint pages `content/pages/footprint/2026/travel.md`, `content/pages/footprint/2026/reading.md`, and `content/pages/footprint/2026/poster.md` and update `content/pages/footprint/_index.md` to link to 2026. 
- Update `data/footprint.yaml` to include a `2026` section with empty month rows and reuse YAML anchors for empty rows. 
- Reorganize `data/books.yaml`, `data/movies.yaml`, and `data/mental_links.yaml` by adding top-level year keys (for example `2025`, `2024`, `2023`, `2022`) alongside existing entries. 
- Modify templates `layouts/partials/mentalfood/year.html` and theme shortcode `themes/aether/layouts/shortcodes/mentalfood.html` to detect map- vs list-shaped `site.Data` inputs, extract year groups, and render year anchors and headings using full-year strings while preserving legacy behavior.

### Testing

- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07cc639e088321acede568dbfc99a8)