### PR TITLE
Configure Pages CMS posts collection

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -3,6 +3,92 @@ media:
   output: /images
 
 content:
+  - name: posts
+    label: Posts 文章
+    type: collection
+    path: content/posts
+    format: yaml-frontmatter
+    subfolders: true
+    filename:
+      template: "{year}/{year}{month}{day}.md"
+      field: create
+    view:
+      fields: [title, date, categories, series, draft]
+      primary: title
+      sort: [date, title, categories]
+      search: [title, description, categories, series, tags, body]
+      default:
+        sort: date
+        order: desc
+    fields:
+      - name: title
+        label: 标题
+        type: string
+        required: true
+        description: 文章标题；会作为后台列表主标题，也可用于生成文件名。
+      - name: description
+        label: 摘要 / SEO 描述
+        type: text
+        required: true
+        description: 首页、列表页和搜索结果中显示的简短摘要，建议 40–120 字。
+      - name: date
+        label: 发布日期
+        type: date
+        required: true
+        options:
+          time: true
+          format: "yyyy-MM-dd'T'HH:mm:ssxxx"
+          step: 60
+        description: 输出为 Hugo 可识别的带时区时间，例如 2025-09-15T21:53:53+08:00。
+      - name: categories
+        label: 分类
+        type: select
+        required: true
+        options:
+          multiple: true
+          min: 1
+          max: 1
+          values:
+            - 生活札记
+            - 技术笔记
+            - 博客折腾
+            - 书影音
+            - 行旅
+        description: 当前主题文章通常只放 1 个分类；如需新增分类，可先在这里补充选项。
+      - name: series
+        label: 系列
+        type: string
+        list: true
+        description: 可留空；常用如「夕拾花」「Hugo 博客折腾」「SQL 数据库笔记」「R 数据分析」「回归分析」。
+      - name: tags
+        label: 标签
+        type: string
+        list: true
+        required: true
+        description: 支持多个自由标签，例如：月记、生活、Hugo、SQL、R。
+      - name: toc
+        label: 显示目录
+        type: boolean
+        description: 长文、技术笔记建议开启；短札记或图文记录可关闭。
+      - name: comment
+        label: 开启评论
+        type: boolean
+        description: "旧文常用字段；开启后 front matter 写入 comment: true。"
+      - name: math
+        label: 启用数学公式
+        type: boolean
+        description: 只有包含 LaTeX / 数学公式的文章需要开启。
+      - name: draft
+        label: 草稿
+        type: boolean
+        description: 开启后 Hugo 默认不会发布，适合先在 CMS 中存草稿。
+      - name: body
+        label: 正文
+        type: code
+        options:
+          format: markdown
+        description: 使用 Markdown 源码编辑，能更稳妥保留 Hugo 短代码、HTML、代码块和已有文章格式。
+
   - name: data
     label: Data 数据
     type: group
@@ -312,3 +398,7 @@ components:
                 label: 活动
                 type: string
                 required: true
+
+settings:
+  content:
+    merge: true


### PR DESCRIPTION
### Motivation
- 将文章也纳入 Pages CMS 管理，便于通过后台新增/编辑 Markdown 博文并保持与现有 Hugo front matter 结构兼容。
- 根据现有 `content/posts` 中文章的 front matter 自动推断常用字段并生成一个可维护、易扩展的表单 schema。

### Description
- 在 `.pages.yml` 中新增 `posts` collection，指向 `content/posts`，使用 `format: yaml-frontmatter`、`subfolders: true` 并设置默认文件名模板为 `{year}/{year}{month}{day}.md` 以匹配按年份的目录结构。 
- 配置后台视图（`view`）以展示 `title, date, categories, series, draft`，并支持按 `date` 降序排序与对 `title, description, categories, series, tags, body` 的搜索。 
- 定义文章字段：`title`, `description` (text), `date` (带时区和分钟步进的 `date` 类型), `categories` (受限选择项，保留当前常用分类), `series` (list), `tags` (list), `toc/comment/math/draft`（boolean），以及将正文作为 `code` 编辑器并设置 `format: markdown` 以保留 Hugo 短代码和原始 Markdown。 
- 修复了一个 YAML 语法问题（为含冒号的 `description` 字符串增加引号）并启用 `settings.content.merge: true`，以在 CMS 保存时尽量保留未在表单中列出的现有 front matter 字段。 

### Testing
- 验证 YAML 语法：运行 `ruby -e 'require "yaml"; YAML.load_file(".pages.yml"); puts "YAML OK"'`，结果通过且返回 `YAML OK`。 
- 站点构建：运行 `hugo --minify`，构建成功（仅包含与现有配置相关的 deprecation 警告）。 
- 内容分析：运行小脚本扫描 `content/posts` 的 front matter（自动统计字段分布）以确认新 schema 与现有文章一致，脚本已成功运行并用于调整字段与分类选项。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d3ff91548321b4d1ddf56245b5b0)