### PR TITLE
Adjust heatmap max width

### DIFF
--- a/themes/aether/layouts/partials/heatmap.html
+++ b/themes/aether/layouts/partials/heatmap.html
@@ -107,7 +107,8 @@
     --heatmap-level-3: rgba(122, 168, 116, 0.74);
     --heatmap-level-4: #7aa874;
     --heatmap-text: rgba(102, 102, 102, 0.9);
-    max-width: 660px;
+    box-sizing: border-box;
+    max-width: min(100%, 760px);
     margin: 0.75rem auto 1.5rem;
     padding: 0.8rem 0.9rem;
     border: 1px solid var(--heatmap-border);


### PR DESCRIPTION
### Motivation
- Prevent the yearly heatmap from being clipped on large screens while avoiding excessive trailing whitespace by relaxing the fixed width cap.

### Description
- In `themes/aether/layouts/partials/heatmap.html` replace the fixed `max-width: 660px;` with `box-sizing: border-box;` and `max-width: min(100%, 760px);` so the heatmap card can expand on wide screens but remains capped.

### Testing
- Built the site with `hugo --minify` which completed successfully.
- Ran `git diff --check` with no issues reported.
- Launched a local dev server and captured a site screenshot with Playwright at `1280x900`, confirming the output PNG was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a083ad82bf0832195823eec79539836)