### PR TITLE
Rewrite TOC styling article for clarity and technical depth

### DIFF
--- a/content/posts/2025/20250915.md
+++ b/content/posts/2025/20250915.md
@@ -9,72 +9,314 @@ comment: true
 toc: true
 ---
 
-本文解决的是 Hugo 博客目录（TOC）层级不够清晰、交互反馈偏弱的问题：在不改 JavaScript 的前提下，通过 SCSS 调整标记点、引导线、悬停态和容器样式，让长文目录更好读也更好用。
+本文解决的是 Hugo 博客目录（TOC）层级不够清晰、交互反馈偏弱的问题：在不改 Hugo 目录生成逻辑、也不改 JavaScript 交互逻辑的前提下，只通过 SCSS 调整标记点、引导线、悬停态和容器样式，让长文目录更好读也更好用。
+
+![](https://img.philohao.com/blog/2025/09/20250915-01.webp)
 
 ## 适用场景
 
-适合已经启用 Hugo 文章目录、但默认 TOC 在长文中显得层级混乱或视觉过轻的博客。尤其是经常写技术教程、读书笔记这类多级标题文章时，目录样式的可读性会直接影响阅读体验。
+适合已经启用 Hugo 文章目录、但默认 TOC 在长文中显得层级混乱或视觉过轻的博客。尤其是经常写技术教程、读书笔记、折腾记录这类多级标题文章时，目录样式的可读性会直接影响阅读体验。
+
+如果你的需求是「目录能生成，但看起来不够像一个好用的导航」，这篇就比较对症；如果你想改的是目录锚点生成、滚动监听或移动端抽屉，那就属于更底层的模板和 JS 改造了。
 
 ## 背景
 
 最近在看自己的网站时，觉得文章右侧的目录（Table of Contents）样式有些单调。它虽然能用，但在视觉上还有很大的提升空间。
 
-![](https://img.philohao.com/blog/2025/09/20250915-01.webp)
+原来的目录主要依赖简单圆点和缩进来表达层级。短文还好，一旦文章标题多起来，问题就明显了：一级、二级、三级标题之间的区分不够直观；鼠标移上去也没有明确反馈；浮动目录贴在页面边上时，存在感有点尴尬，既不像正文的一部分，也不像一个独立组件。
 
-可以看到，它只用了简单的圆点和缩进，层级关系不够直观，交互感也比较弱。我的目标是：在不修改任何 JavaScript 的前提下，只通过 CSS (SCSS) 来让它变得更美观、更实用。
+所以这次改造的目标其实很克制：**不推倒重来，只把原有 TOC 打磨得更像一个可读、可点、可维护的小导航**。
 
-## 核心步骤
+## 先看清楚原来的工作方式
 
-### 第一版改造：四大优化方向
+动手之前，我先把主题里和 TOC 有关的链路理了一遍。Aether 主题的目录并不是我手写出来的，而是沿用 Hugo 的 `.TableOfContents`，再由主题模板和 JS 决定它放在哪里、什么时候高亮。
 
-经过分析，我确定了四个主要的优化方向，并进行了第一轮的样式修改。
+### 1. Hugo 负责生成目录结构
 
-#### 1. 增强层级感
+在文章模板里，静态目录和浮动目录共用同一份 Hugo 输出：
 
-为了让目录结构一目了然，我做了两处关键改动：
+```go-html-template
+{{- dict "Content" .TableOfContents "Ruby" $params.ruby "Fraction" $params.fraction "Fontawesome" $params.fontawesome | partial "function/content.html" | safeHTML -}}
+```
 
-- **区分标记点**：用不同的符号来表示不同级别的标题。一级目录用实心圆 ●，二级目录用空心圆 ○，三级目录则用更细的 ◌。
-- **增加引导线**：在次级目录的左侧，增加一条垂直的引导线。这条线能非常清晰地将子标题“收纳”在父标题之下，结构感瞬间增强。
+也就是说，目录最核心的 HTML 结构来自 Hugo 本身。它通常会生成类似这样的嵌套列表：
 
-#### 2. 增加交互反馈
+```html
+<nav id="TableOfContents">
+  <ul>
+    <li><a href="#背景">背景</a></li>
+    <li>
+      <a href="#核心步骤">核心步骤</a>
+      <ul>
+        <li><a href="#增强层级感">增强层级感</a></li>
+      </ul>
+    </li>
+  </ul>
+</nav>
+```
 
-一个好的界面应该能对用户的操作做出反馈，之前的目录，鼠标放上去没有任何变化。
+这个结构有一个好处：天然就是 `ul > li > a > ul` 的树状结构。换句话说，层级关系其实已经在 HTML 里了，我没有必要为了视觉效果去改模板，只要让 CSS 更好地「读懂」这棵树就行。
 
-- **悬停效果 (:hover)**： 为每个目录链接添加了 :hover 伪类。当鼠标悬停在链接上时，会改变文字颜色并出现一个淡淡的背景色。这个简单的改动能明确告诉用户“这里可以点击”。
+### 2. 模板准备两个容器
 
-#### 3. 优化容器外观
+主题模板里同时准备了两个目录容器：
 
-无论是浮动目录还是静态目录，我都想让它们看起来更像一个精心设计的“卡片”，而不是简单的文字列表。
+- `#toc-auto`：桌面端右侧浮动目录；
+- `#toc-static`：正文里的静态折叠目录。
 
-- 浮动目录 (#toc-auto)： 为其增加了半透明的背景和右侧的圆角。这样即使页面背景复杂，目录依然清晰可读。
-- 静态目录 (#toc-static)： 将其从类似代码块的深色背景，改为了带有圆角和细边框的简洁样式，更好地融入文章内容。
+浮动目录先给一个空容器：
 
-#### 4. 调整布局方式
+```html
+<div class="toc" id="toc-auto">
+  <h2 class="toc-title">目录</h2>
+  <div class="toc-content" id="toc-content-auto"></div>
+</div>
+```
 
-放弃了原先 text-indent 的缩进方式，改用 position: relative 和 padding-left 来布局，这样能更精确地控制标记点和文字的位置，避免错位问题。
+静态目录则放在正文标题之后、文章内容之前：
 
-### 第二版微调：优化行间距
+```html
+<div class="details toc" id="toc-static">
+  <div class="details-summary toc-title">...</div>
+  <div class="details-content toc-content" id="toc-content-static">
+    {{ .TableOfContents }}
+  </div>
+</div>
+```
 
-第一版改造后，整体效果已经很不错了，但我发现一个细节问题：每一行的行间距似乎有点大，目录显得有些松散。
+这里的设计挺巧妙：页面上只有一份真正的 `#TableOfContents`，但它可以被放进不同容器。也正因为如此，我这次改样式时尽量把通用规则写在 `.toc` 下，再针对 `#toc-auto` 和 `#toc-static` 分别补外观。
 
-这个问题主要来源于我为了增加链接点击区域而在 a 标签上设置的 padding 值。
+### 3. JavaScript 负责搬运和高亮
 
-调整方法很简单：
+主题的 `initToc()` 会判断当前该使用静态目录还是浮动目录，然后把 `#TableOfContents` 移到对应容器中。如果使用浮动目录，它还会做三件事：
 
-找到 `.toc .toc-content ul a` 选择器，将其 padding 的垂直值从 4px 或 2px 直接改为 0。
+1. 根据文章区域位置计算 `#toc-auto` 的 `left` 和 `maxWidth`；
+2. 根据滚动位置在 `absolute` 和 `fixed` 之间切换；
+3. 给当前标题对应的目录链接加上 `.active`，同时给父级 `li` 加上 `.has-active`。
 
-修改前： `padding: 2px 0;`
+这就解释了为什么我不想碰 JS：滚动定位、当前阅读位置、高亮父级这些逻辑本来就是通的。我要解决的是「这些状态出现以后，视觉上怎么表达得更清楚」。
 
-修改后： `padding: 0 0;`
+## 设计原则
 
-同时，也移除了层级之间 ul 的 margin 值，让整个列表更加紧凑。
+理清底层以后，这次改造就不是简单地「加点好看的 CSS」，而是围绕几个限制来做取舍。
 
+### 1. 不改目录语义
+
+目录本质上还是一个导航列表，所以我保留 Hugo 生成的 `nav / ul / li / a` 结构，不额外包裹 span，也不在模板里塞装饰字符。层级标记全部交给 `::before` 伪元素，这样 HTML 仍然干净，后续换主题或排查锚点问题也更安心。
+
+### 2. 通用样式优先，容器样式分开
+
+`.toc` 里只放「目录作为列表」的通用规则，例如字号、列表重置、链接布局、层级标记、引导线、hover 状态。
+
+`#toc-auto` 和 `#toc-static` 则只负责各自的容器气质：浮动目录更像贴在页面右侧的轻量导航卡片；静态目录更像正文中的折叠信息块。这样拆开后，哪怕以后移动端或桌面端显示策略变了，列表本身的层级表达也不用重写。
+
+### 3. 尽量接入主题变量
+
+颜色没有写死成某一个蓝色或灰色，而是优先使用主题已有变量，比如 `$single-link-hover-color`、`$global-border-color`、`$code-background-color`。这样浅色、深色、黑色三套主题能一起适配，不会出现浅色主题好看、深色主题突然刺眼的问题。
+
+当然，这也带来一个小取舍：这份 SCSS 不是完全独立的组件，迁移到别的主题时，需要先把这些变量替换成目标主题自己的颜色体系。
+
+## 核心改造
+
+### 1. 用伪元素表达层级，而不是依赖默认圆点
+
+原来的目录层级主要靠浏览器默认列表样式和缩进。这个方案能用，但视觉信息太弱。我的改法是先把默认列表样式拿掉：
+
+```scss
+.toc {
+  .toc-content {
+    ul {
+      padding-left: 0;
+      list-style: none;
+    }
+  }
+}
+```
+
+然后把每个链接变成可定位的块级元素：
+
+```scss
+.toc .toc-content ul a {
+  display: block;
+  position: relative;
+  padding-left: 1.35rem;
+  text-decoration: none;
+}
+```
+
+这里的 `padding-left: 1.35rem` 很关键，它不是单纯缩进文字，而是给左侧的伪元素预留一个稳定位置。后面无论是实心圆、空心圆，还是高亮状态，都可以画在这块区域里，文字本身不会跟着晃。
+
+层级标记则用直接子代选择器区分：
+
+```scss
+.toc .toc-content ul > li > a::before {
+  content: "●";
+}
+
+.toc .toc-content ul ul > li > a::before {
+  content: "○";
+}
+
+.toc .toc-content ul ul ul > li > a::before {
+  content: "◌";
+}
+```
+
+这里我选择 `● / ○ / ◌`，不是为了花哨，而是因为它们在小字号下仍然比较容易分辨：一级标题更重，二级标题更轻，三级标题再往后退一点。读者扫一眼目录，就能大概知道文章骨架。
+
+### 2. 用引导线把子标题「收」到父标题下面
+
+只有不同圆点还不够，长文里多个二级、三级标题连续出现时，眼睛还是容易飘。所以我给子级 `ul` 增加了一条细引导线：
+
+```scss
+.toc .toc-content ul ul {
+  padding-left: 1rem;
+  position: relative;
+}
+
+.toc .toc-content ul ul::before {
+  content: '';
+  position: absolute;
+  left: 0.35rem;
+  top: 0.5rem;
+  bottom: 0.5rem;
+  width: 1px;
+  background-color: $global-border-color;
+}
+```
+
+这条线的作用不是装饰，而是帮助眼睛理解「这一组小标题属于上面的父标题」。尤其是浮动目录宽度有限时，文字会换行，如果没有这条线，层级关系就更容易散掉。
+
+`top` 和 `bottom` 没有写成 `0`，是为了让线条不要顶到整组列表的边缘，视觉上会轻一点，也不会像表格边框一样生硬。
+
+### 3. hover 反馈要明显，但不能抢正文
+
+目录是导航，鼠标移上去应该有反馈。我的处理是文字变成链接 hover 色，同时给一个很淡的背景：
+
+```scss
+.toc .toc-content ul a:hover {
+  color: $single-link-hover-color;
+  background-color: rgba($global-border-color, 0.5);
+  border-radius: 4px;
+}
+```
+
+这个背景色故意取得很轻，因为目录始终是辅助组件，不能比正文内容更抢眼。真正需要强调的是「这里可以点击」，而不是做成按钮一样的强交互。
+
+深色和黑色主题则单独降低透明度：
+
+```scss
+[theme=dark] & {
+  color: $single-link-hover-color-dark;
+  background-color: rgba($global-border-color-dark, 0.2);
+}
+```
+
+深色模式下如果透明度过高，hover 背景会显得一块一块的，反而不耐看。这里用 `0.2`，基本就是给用户一个轻提示。
+
+### 4. active 状态复用 hover 色
+
+浮动目录有滚动高亮逻辑，JS 会给当前目录链接加 `.active`。所以样式上我让 active 链接加粗，并复用 hover 色：
+
+```scss
+#toc-auto .toc-content ul a.active {
+  font-weight: bold;
+  color: $single-link-hover-color;
+}
+
+#toc-auto .toc-content ul a.active::before {
+  color: $single-link-hover-color;
+}
+```
+
+这里有一个小细节：不仅文字要变色，前面的圆点也要一起变色。否则当前标题虽然高亮了，但标记点还停留在默认颜色，会有一点割裂。
+
+同时，主题 JS 会给 active 链接的父级加 `.has-active`。原样式里子级目录默认折叠，我保留了这个逻辑：
+
+```scss
+#toc-auto .toc-content ul ul {
+  display: none;
+}
+
+#toc-auto .toc-content ul .has-active > ul {
+  display: block;
+}
+```
+
+这样浮动目录不会一次性把所有层级都摊开，而是跟着当前阅读位置展开相关分支。对长文来说，这比完整展开更清爽。
+
+### 5. 浮动目录做成轻量卡片
+
+浮动目录原本更像一列贴在旁边的文字。我希望它更像一个「独立但不突兀」的导航卡片，所以加了内边距、边框、圆角和背景模糊：
+
+```scss
+#toc-auto {
+  padding: 0 1rem;
+  border: 1px solid #b1b1b1;
+  border-left: 3px solid $global-border-color;
+  border-radius: 0 8px 8px 0;
+  @include blur;
+}
+```
+
+这里左边框比其他边更粗，是为了保留一点「侧边导航」的感觉；右侧圆角则让它不要像浏览器原生边框那么硬。`@include blur` 继续沿用主题已有的毛玻璃效果，和站内其他组件保持一致。
+
+不过它仍然由 JS 控制位置：初始 `visibility: hidden`，等 `initToc()` 算好文章右侧位置后再显示。这样可以避免页面刚加载时目录闪一下。
+
+### 6. 静态目录融入正文
+
+静态目录在正文里出现时，读者会把它当成文章内容的一部分，所以我没有给它做太强的浮层感，而是改成边框卡片：
+
+```scss
+#toc-static {
+  margin: 1.5rem 0;
+  border: 1px solid $global-border-color;
+  border-radius: 8px;
+  overflow: hidden;
+}
+```
+
+标题栏继续使用代码块背景色：
+
+```scss
+#toc-static .toc-title {
+  display: flex;
+  justify-content: space-between;
+  line-height: 2em;
+  padding: 0.5rem 1rem;
+  background: $code-background-color;
+  cursor: pointer;
+}
+```
+
+`cursor: pointer` 是一个很小但很重要的提示，因为静态目录本质上是可折叠的 details 组件。用户看到鼠标样式变化，就会知道标题栏不是普通文本。
+
+### 7. 行间距最后再收紧
+
+第一版改完后，整体效果已经出来了，但目录看起来还有点松散。问题主要来自链接的上下 `padding`：我一开始为了扩大点击区域，给了 `2px 0`，结果目录项一多就显得臃肿。
+
+最后我把它收成：
+
+```scss
+padding: 0 0;
+padding-left: 1.35rem;
+```
+
+注意这里不是把点击体验完全牺牲掉，而是因为目录本身有行高，链接又是 `display: block`，实际可点区域仍然够用。对于右侧浮动目录这种窄组件来说，紧凑一点反而更适合。
 
 ## 最终效果
 
-改造后的目录用不同符号和缩进表达层级，用 hover 状态提示可点击区域，并让浮动目录、静态目录都更像页面中的信息卡片。视觉上不会喧宾夺主，但足够支撑长文快速跳转。
+改造后的目录主要解决了三个问题：
+
+1. **层级更清楚**：不同标记点加上子级引导线，标题树更容易扫读；
+2. **状态更明确**：hover 和 active 都有颜色反馈，当前阅读位置更好判断；
+3. **容器更完整**：浮动目录像侧边导航卡片，静态目录像正文信息块，两者都不再只是散落的文字列表。
+
+这次我比较满意的地方在于，它没有改变 Hugo 的目录生成方式，也没有动主题原有的滚动监听。目录仍然是那份目录，只是 CSS 更准确地把它的结构和状态表达出来了。
 
 ## 最终代码展示
+
+下面是这次改造后的核心 SCSS，主要对应主题里的 `themes/aether/assets/css/_partial/_single/_toc.scss`：
 
 ```scss
 // --- 变量定义 (假设这些变量已在别处定义) ---
@@ -96,24 +338,22 @@ toc: true
   .toc-content {
     font-size: $toc-content-font-size;
 
-    // --- 移除 text-indent, 使用更现代的 Flexbox/Grid 或伪元素布局 ---
+    // --- 移除 text-indent，改用伪元素和 padding-left 控制层级 ---
     ul {
-      padding-left: 0; // 重置内边距, 在 a 标签上控制
+      padding-left: 0;
       list-style: none;
 
       a {
-        // --- 优化: 将 a 标签设为块级或行内块, 方便添加 padding 和 hover 背景 ---
         display: block;
-        padding: 0 0; // --- 调整这里 (1): 减小链接的上下内边距来缩小行距 ---
+        padding: 0 0;
         position: relative;
-        padding-left: 1.35rem; // 为伪元素留出空间
-        text-decoration: none; // 确保没有下划线
-        transition: color 0.2s, background-color 0.2s; // 平滑过渡
+        padding-left: 1.35rem;
+        text-decoration: none;
+        transition: color 0.2s, background-color 0.2s;
 
-        // --- 新增: 鼠标悬停效果 ---
         &:hover {
           color: $single-link-hover-color;
-          background-color: rgba($global-border-color, 0.5); // 添加一个淡淡的背景色
+          background-color: rgba($global-border-color, 0.5);
           border-radius: 4px;
 
           [theme=dark] & {
@@ -127,10 +367,8 @@ toc: true
         }
       }
 
-      // --- 优化: 使用 > 选择器区分层级 ---
-      // Level 1
       > li > a::before {
-        content: "●"; // 使用实心圆点作为一级标记
+        content: "●";
         font-weight: bolder;
         position: absolute;
         left: 0;
@@ -142,17 +380,13 @@ toc: true
       }
 
       ul {
-        padding-left: 1rem; // 子列表的缩进
-        // --- 调整这里 (2): 减小层级之间的垂直间距 ---
-        // margin-top: 0.1rem;
-        // margin-bottom: 0.1rem;
-
-        // --- 新增: 视觉引导线 ---
+        padding-left: 1rem;
         position: relative;
+
         &::before {
           content: '';
           position: absolute;
-          left: 0.35rem; // 调整线的位置
+          left: 0.35rem;
           top: 0.5rem;
           bottom: 0.5rem;
           width: 1px;
@@ -161,20 +395,17 @@ toc: true
           [theme=black] & { background-color: $global-border-color-black; }
         }
 
-        // Level 2
         > li > a::before {
-          content: "○"; // 使用空心圆点
+          content: "○";
         }
 
-        // Level 3 (如果需要)
         ul > li > a::before {
-          content: "◌"; // 使用更小的空心圆点
+          content: "◌";
         }
       }
     }
   }
 
-  // --- ruby 样式 ---
   ruby {
     background: $code-background-color;
 
@@ -205,17 +436,15 @@ toc: true
   position: absolute;
   width: $MAX_LENGTH;
   max-width: 0;
-  // --- 优化: 增加内边距, 让内容有呼吸空间 ---
   padding: 0 1rem;
-  border-left: 3px solid $global-border-color; // 边框稍微细一点
+  border: 1px solid #b1b1b1;
+  border-left: 3px solid $global-border-color;
   @include overflow-wrap(break-word);
   box-sizing: border-box;
   top: 10rem;
   left: 0;
   visibility: hidden;
-
-  // --- 新增: 半透明背景, 提升可读性 ---
-  border-radius: 0 8px 8px 0; // 右侧添加圆角
+  border-radius: 0 8px 8px 0;
   @include blur;
 
   [theme=dark] & {
@@ -235,10 +464,9 @@ toc: true
 
   .toc-content {
     ul {
-      // --- 优化: 为 active 状态的伪元素也应用高亮颜色 ---
       a.active {
         font-weight: bold;
-        color: $single-link-hover-color; // 使用 hover 颜色以示强调
+        color: $single-link-hover-color;
         [theme=dark] & { color: $single-link-hover-color-dark; }
         [theme=black] & { color: $single-link-hover-color-black; }
 
@@ -268,13 +496,13 @@ toc: true
   }
 }
 
-// --- 静态目录 (页面内) ---
+// --- 静态目录（页面内） ---
 #toc-static {
   display: none;
-  margin: 1.5rem 0; // 增加上下边距
-  border: 1px solid $global-border-color; // --- 优化: 使用边框代替背景色, 更简洁
+  margin: 1.5rem 0;
+  border: 1px solid $global-border-color;
   border-radius: 8px;
-  overflow: hidden; // 配合圆角
+  overflow: hidden;
 
   [theme=dark] & { border-color: $global-border-color-dark; }
   [theme=black] & { border-color: $global-border-color-black; }
@@ -289,18 +517,18 @@ toc: true
     line-height: 2em;
     padding: 0.5rem 1rem;
     background: $code-background-color;
-    cursor: pointer; // --- 新增: 表明标题可点击
+    cursor: pointer;
 
     [theme=dark] & { background: $code-background-color-dark; }
     [theme=black] & { background: $code-background-color-black; }
   }
 
   .toc-content {
-    background-color: transparent; // --- 优化: 移除背景色, 使其与文章背景一致
+    background-color: transparent;
 
     > nav > ul {
       margin: 0;
-      padding: .8rem 1rem .8rem 1rem; // 统一内边距
+      padding: .8rem 1rem .8rem 1rem;
     }
   }
 }
@@ -308,7 +536,11 @@ toc: true
 
 ## 小结
 
-最终方案是保留 Hugo 原有 TOC 生成逻辑，只在 SCSS 层做视觉增强。这样风险较低，不会影响目录锚点和滚动定位；取舍是样式对主题变量依赖较强，迁移到其他主题时需要重新适配。后续可以继续优化移动端折叠、当前阅读位置高亮，以及多级标题过深时的显示策略。
+这次 TOC 改造看起来只是改样式，但真正重要的是先弄清楚边界：Hugo 负责生成目录结构，模板负责提供静态和浮动两个容器，JavaScript 负责搬运目录与滚动高亮，而 SCSS 负责把层级、状态和容器气质表达清楚。
+
+最终方案的优点是风险比较低：不影响目录锚点，不影响滚动定位，也不需要维护额外脚本；缺点是样式和 Aether 主题变量绑定较深，迁移到其他主题时需要重新适配。
+
+后续如果继续优化，我可能会再看看移动端折叠目录、当前阅读位置的过渡动画，以及多级标题过深时是否需要限制显示层级。但当前这个版本已经足够解决一个很实际的问题：长文目录终于不再只是「能用」，而是开始「好读」了。
 
 ## 参考资料
 


### PR DESCRIPTION
### Motivation
- Improve the original TOC post so the design choices, assumptions and implementation details are explicit and easier to follow for readers who want to reproduce or adapt the work. 
- Keep the scope constrained: explain SCSS-level changes that enhance hierarchy, guide lines and hover/active states without changing Hugo's TOC generation or the theme JS behavior. 
- Preserve the article's original creation metadata (date and location) while making structure and reasoning clearer.

### Description
- Rewrote and reorganized `content/posts/2025/20250915.md` to add a clear explanation of the underlying pipeline (Hugo `.TableOfContents`, theme containers `#toc-auto` / `#toc-static`, and the theme `initToc()` JS responsibilities) and the constraints that guided the CSS-only approach. 
- Added a `Design principles` section and expanded `核心改造` to document technical choices (use of `::before` pseudo-elements for hierarchy markers, vertical guide lines on child `ul`, switch from `text-indent` to `padding-left` + `position: relative`, hover/active styling, and container distinctions between floating and static TOC). 
- Included the final SCSS snippets and rationale (variable-driven colors, compact spacing adjustments, and notes about theme variable coupling), while ensuring the article still references the same date/place in the footer.

### Testing
- Ran `hugo --minify` to validate the site build with the updated content, and the build completed successfully. 
- Ran `git diff --check` to ensure there are no whitespace or diff errors, and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a083f48ba6483218029fae3528c2f7d)