### PR TITLE
Update Hugo data-files post and enhance TOC styling / examples

### DIFF
--- a/content/posts/2025/20250828.md
+++ b/content/posts/2025/20250828.md
@@ -9,17 +9,19 @@ comment: true
 toc: true
 ---
 
-本文解决的是 Hugo 页面里结构化书影音记录难维护的问题：把原本塞在 Markdown 里的 Shortcode 参数迁移到 Data Files 中，让内容数据、页面结构和展示代码分离，后续新增记录时只改 YAML 数据即可。
+本文解决的是 Hugo 页面里结构化内容难维护的问题：把原本塞在 Markdown 里的 Shortcode 参数迁移到 Data Files 中，让内容数据、页面结构和展示代码分离。现在这个思路不只用在书影记录，也扩展到了书刊、影剧、摘录链接和足迹年度表格这些页面里。
 
 ## 适用场景
 
-适合在 Hugo 中维护书单、影单、友链、项目列表等重复卡片内容的页面。只要内容条目字段相对固定、数量会持续增加，就可以考虑用 Data Files 替代一条条手写 Shortcode。
+适合在 Hugo 中维护书单、影单、友链、项目列表、旅行足迹、年度清单等重复内容。只要内容条目的字段相对固定、数量会持续增加，就可以考虑用 Data Files 替代一条条手写 Shortcode。
+
+如果你的页面只有三五条内容，直接写 Markdown 最简单；但如果一年下来会积累几十本书、几十部电影、很多条视频链接，甚至还要跨年份展示，那就很适合把「数据」从正文里拆出去。
 
 ## 背景
 
-网站上有一个[书影游]({{< relref "pages/footprint/2025/reading.md" >}})页面，用来记录我看过的书和电影。之前为了显示效果，自定义了一个叫 `mediacard` 的 Shortcode，可以在页面上生成卡片。
+网站上原来有一个[书影游]({{< relref "pages/footprint/2025/reading.md" >}})页面，用来记录我看过的书和电影。为了显示效果，我一开始写了一个 `mediacard` Shortcode，每条记录都在 Markdown 里调用一次。
 
-在 Markdown 文件里，每条记录都是一次 Shortcode 调用，像这样：
+大概长这样：
 
 ```markdown
 {{</* mediacard title="大唐双龙传" 
@@ -30,134 +32,352 @@ toc: true
 */>}}
 ```
 
-刚开始记录不多的时候，这个方法还行。但后来东西越来越多，整个 Markdown 文件就变得特别长，每次想加一条新记录，都要在文件里找很久，维护起来很麻烦。
+刚开始记录不多的时候，这种方式还挺直观。但后来问题越来越明显：
 
-## 核心步骤
+- Markdown 文件越来越长，一条记录就是一大段 Shortcode；
+- 书和电影混在页面里，想按年份、月份整理很麻烦；
+- 如果卡片样式要改，虽然可以改 Shortcode，但字段结构本身还是散在正文里；
+- 后来又想记录文章、视频、播客摘录，继续堆 Shortcode 会越来越乱；
+- 足迹页面也有类似问题，年度、月份、城市、活动这些信息本质上也是结构化数据。
 
-### 解决方法
+所以这次折腾的核心不是「写一个更厉害的短代码」，而是反过来想：**页面正文应该只描述页面，重复条目应该变成数据。**
 
-主要思路就是把**数据**和**页面**分开。
+## 现在的数据文件结构
 
-Hugo 本身提供了 Data Files 功能，允许在 `/data` 目录下存放 YAML、JSON 或 TOML 格式的数据文件。这样，Markdown 文件就只负责页面结构和展示逻辑，而具体的书影条目数据，则统一放到数据文件里，方便管理。
+现在本站用到的数据文件主要放在 `data/` 目录下，其中和这篇文章最相关的是四个：
 
-### 具体步骤
-
-#### 1. 把数据转移到 `data` 文件夹
-
-第一步是把之前写在 Markdown 文件里的所有条目数据，都整理出来，放到 `/data` 文件夹下，这种脏活累活当然是交给 AI 来完成啦！
-
-我新建了 `books.yaml` 和 `movies.yaml` 两个文件。
-
-**修改前 (在 `.md` 文件里):**
-```markdown
-{{</* mediacard title="法师故事" coverurl="..." author="索斯" type="24-08" ... */>}}
+```text
+data/
+├── books.yaml         # 书刊清单
+├── movies.yaml        # 影剧清单
+├── mental_links.yaml  # 精神食粮 / 摘录链接
+└── footprint.yaml     # 足迹年度表格：出游、书影游、海报墙
 ```
 
-**修改后 (在 `data/books.yaml` 文件里):**
+这里有一个和最初版本很不一样的变化：**现在数据不再是一个扁平列表，而是优先按年份分组。**
+
+最早我只是把所有书塞进 `books.yaml`，再靠 `type: 24-08` 这种字段过滤年份。现在的结构更接近这样：
+
 ```yaml
-- title: "法师故事"
-  coverurl: "[https://bookcover.yuewen.com/qdbimg/349573/57821/600.webp](https://bookcover.yuewen.com/qdbimg/349573/57821/600.webp)"
-  link: "[https://www.qidian.com/book/57821/](https://www.qidian.com/book/57821/)"
-  author: "索斯"
-  type: "24-08"
-  starscore: "★★★★"
-  greystar: "☆"
-  intro: "魔兽践踏，巨龙咆哮，巫师诅咒，魔法璀璨之光照耀知识灯塔！"
+"2025":
+  - title: 大唐双龙传
+    coverurl: https://neodb.social/m/book/2021/09/17dd81c9b9-0e2d-47fe-9b08-30b4c732249f.jpg
+    link: https://neodb.social/book/7TpGOqhdp2Q87oZn8wj0xc
+    author: 黄易
+    type: 25-01
+    starscore: "★★★"
+    greystar: "☆☆"
+    intro: 以隋末唐初群雄割据的动荡局面为背景，叙述了扬州城里的寇仲和徐子陵由两个小混混成长为两个武林绝顶高手的历程。一言以蔽之，大唐双龙奇遇记。
+"2024":
+  - title: 某霍格沃茨的魔文教授
+    type: 24-01
 ```
-这样一来，所有的数据都集中管理了，之后增删改查也只用编辑这两个 `.yaml` 文件就行。
 
-#### 2. 写一个新的 Shortcode
+这种结构有两个好处：
 
-因为数据存放的位置变了，所以需要一个新的 Shortcode 来读取这些数据并显示出来。
+1. 文件打开后，一眼就能定位到某一年；
+2. 渲染年度页面时，可以直接 `index site.Data.books "2025"`，不用每次遍历全量数据再筛选。
 
-我在 `layouts/shortcodes/` 目录下新建了一个 `medialist.html` 文件。这个 Shortcode 接收两个参数：第一个是数据文件名（比如 "books"），第二个是年份（比如 "24"），用来筛选对应年份的数据。
+当然，`type` 字段还是保留了，因为它承担的是「月份归档」的职责。也就是说，年份由外层 key 负责，月份由 `type: YY-MM` 负责。
 
-代码如下：
-```html
-{{- $dataFile := .Get 0 -}}
-{{- $yearPrefix := .Get 1 -}}
+## 四类数据分别管什么
 
-{{- if not $dataFile -}}
-  {{- errorf "medialist shortcode in %s: 缺少第一个参数 (数据文件名)。" .Page.Path -}}
+### 1. `books.yaml`：书刊清单
+
+`books.yaml` 用来放读过的书、网文、杂志等，核心字段是：
+
+```yaml
+"2025":
+  - title: 鬼吹灯
+    coverurl: https://neodb.social/m/book/2021/11/018eff31ee-9fb7-4f62-91d1-5f5b609d64c3.jpg
+    link: https://book.douban.com/subject/34452623/
+    author: 天下霸唱
+    type: 25-06
+    starscore: "★★★★★"
+    greystar: ""
+    intro: 鬼吹灯是一个系列形式的文字冒险故事，以一本家传的秘书残卷为引。
+```
+
+这里我没有把字段设计得特别复杂，基本还是围绕一张卡片需要什么来定：封面、链接、作者、月份、评分和短评。这样数据文件虽然朴素，但和页面展示是一一对应的。
+
+### 2. `movies.yaml`：影剧清单
+
+`movies.yaml` 和 `books.yaml` 结构几乎一样，只是 `author` 在这里更像「导演 / 主创」。保持字段一致有一个现实好处：书刊和影剧可以共用同一个渲染 partial，不需要写两套卡片模板。
+
+```yaml
+"2025":
+  - title: 嗜血法医 第一季 (2006)
+    coverurl: https://neodb.social/m/movie/2021/11/27101089f8-d0e8-4532-b500-3b1a6412617c.jpg
+    link: https://neodb.social/tv/season/2GvfGAZ9FdHG3qwhLpNANz
+    author: Michael Cuesta/托尼·戈德温
+    type: 25-02
+    starscore: "★★★★"
+    greystar: "☆☆"
+    intro: 对这种主角略变态且有心理剖析的剧很有兴趣。
+```
+
+字段统一之后，模板里只需要接收一个 `items` 列表，然后按卡片样式循环渲染即可。对我来说，这比为书和电影分别维护两个 Shortcode 更舒服。
+
+### 3. `mental_links.yaml`：文章、视频、播客摘录
+
+后来我发现，「书影游」其实不只应该包括书和电影。平时看到的一些文章、视频、播客，也很值得留下索引，所以又单独拆了一个 `mental_links.yaml`。
+
+它的字段更轻一些：
+
+```yaml
+"2025":
+  - type: 25-08
+    category: 自媒体摘录
+    title: 一个值得回看的内容标题
+    url: https://example.com/
+    source: 某位作者
+```
+
+这里没有封面、评分和短评，因为链接摘录更像一个「稍后回看」列表。我只关心它是什么类型、叫什么、来自哪里、链接在哪。
+
+### 4. `footprint.yaml`：足迹年度表格
+
+`footprint.yaml` 则是另一个方向：它不是卡片流，而是年度表格。现在里面按分类组织：
+
+```yaml
+travel:
+  "2025":
+    title: "2025 出游"
+    rows:
+      - month: "一月"
+        events:
+          - city: "香港"
+            activity: "钓鱼翁徒步"
+      - month: "二月"
+        events:
+          - city: "厦门"
+            activity: "小队两日游"
+reading:
+  "2025":
+    title: "2025 书影游"
+    rows:
+      - month: "一月"
+        events: []
+poster:
+  "2025":
+    title: "2025 海报墙"
+    rows:
+      - month: "一月"
+        events: []
+```
+
+这里的关键是 `travel / reading / poster` 三个分类。它们共用相同的年度表格结构：每一年有一个 `title`，下面是十二个月，每个月可以有多个 `events`。
+
+这样做之后，足迹首页、年度出游、年度书影游、海报墙这些页面就有了同一套数据底座。页面要怎么展示是一回事，但「这一年有哪些月份、每个月有哪些事件」这件事，不再散落在多个 Markdown 文件里。
+
+## 页面结构怎么变了
+
+数据拆出去以后，Markdown 页面就清爽多了。以 `content/pages/footprint/2025/reading.md` 为例，它现在主要只保留页面元信息和一小段说明：
+
+```toml
++++
+title = "2025 书影游"
+description = "2025 年读过的书、看过的影剧和收藏的内容摘录。"
+date = "2025-01-01"
+layout = "footprint-year"
+year = 2025
+category = "reading"
+comment = false
+toc = false
+hiddenFromHomePage = true
+hiddenFromSearch = false
+aliases = ["/pages/mentalfood/"]
++++
+
+## 2025 年书影游
+
+这一页汇总 2025 年读过的书刊、看过的影剧，以及值得回看的文章、视频和播客摘录。
+```
+
+这里最重要的是两个 front matter 字段：
+
+- `year = 2025`：告诉模板当前页面要拿哪一年的数据；
+- `category = "reading"`：告诉模板当前页面属于足迹里的哪个分类。
+
+也就是说，页面不再负责列出所有书和电影，只负责声明「我是 2025 年的书影游页面」。真正的数据读取和渲染，交给 layout 和 partial。
+
+## 底层模板怎么串起来
+
+### 1. 年度足迹页面读取 `data/footprint.yaml`
+
+`layouts/pages/footprint-year.html` 会先从 front matter 里拿到年份和分类：
+
+```go-html-template
+{{- $year := printf "%v" (.Params.year | default "2025") -}}
+{{- $category := .Params.category | default "travel" -}}
+{{- $categoryData := index site.Data.footprint $category | default dict -}}
+{{- $data := index $categoryData $year | default dict -}}
+```
+
+这里其实就是两次 `index`：先通过 `travel / reading / poster` 找到分类，再通过 `2025 / 2024 / 2023` 找到年份。
+
+如果是出游或海报墙页面，模板会把 `$data.rows` 渲染成年度表格；如果是 `reading` 页面，则会走另一条分支：
+
+```go-html-template
+{{- if eq $category "reading" -}}
+  <section class="footprint-detail-flow" aria-label="书影游记录">
+    {{- dict "Content" .Content "Ruby" $params.ruby "Fraction" $params.fraction "Fontawesome" $params.fontawesome | partial "function/content.html" | safeHTML -}}
+    {{- partial "mentalfood/year.html" (dict "year" $year) -}}
+  </section>
 {{- end -}}
-{{- if not $yearPrefix -}}
-  {{- errorf "medialist shortcode in %s: 缺少第二个参数 (年份)。" .Page.Path -}}
-{{- end -}}
+```
 
-{{- $mediaData := index site.Data $dataFile -}}
+这段逻辑的意思是：`reading.md` 自己的 Markdown 正文照常渲染，然后再把这一年的书、影、摘录都交给 `mentalfood/year.html` 这个 partial 来补上。
 
-{{- if $mediaData -}}
-  {{- $count := 0 -}}
-  {{- range $mediaData -}}
-    {{- if (hasPrefix .type $yearPrefix) -}}
+### 2. `mentalfood/year.html` 聚合三份数据
+
+`layouts/partials/mentalfood/year.html` 只关心一件事：给定一个年份，把这一年的书刊、影剧和摘录分别取出来。
+
+```go-html-template
+{{- $year := printf "%v" (.year | default "2025") -}}
+{{- $books := index site.Data.books $year | default slice -}}
+{{- $movies := index site.Data.movies $year | default slice -}}
+{{- $links := index site.Data.mental_links $year | default slice -}}
+```
+
+拿到数据后，它会渲染三个折叠块：
+
+- 书刊：`partial "mentalfood/media-list.html"`；
+- 影剧：同样复用 `partial "mentalfood/media-list.html"`；
+- 摘录：`partial "mentalfood/link-list.html"`。
+
+我比较喜欢这个拆法：年度页面只负责「这是哪一年」，`year.html` 负责「这一年有哪些数据」，具体列表长什么样再交给更小的 partial。每一层都只做一件事，后面要改样式或新增字段时比较不容易牵一发动全身。
+
+### 3. `media-list.html` 统一渲染书和影
+
+书和影之所以能共用 `media-list.html`，是因为它们的字段结构保持一致。渲染时大概就是循环 `items`：
+
+```go-html-template
+{{- $items := .items | default slice -}}
+{{- $empty := .empty | default "本年度暂无记录。" -}}
+{{- $count := 0 -}}
+<div class="media-list">
+  {{- range $items -}}
+    {{- $title := .title | default "" -}}
+    {{- if $title -}}
       {{- $count = add $count 1 -}}
-      <div class="media">
-        <div class="media-cover" style="background-image:url(\{\{ .coverurl \}\})"></div>
-        <div class="media-meta">
-          <div class="media-meta-item title"><a href="\{\{ .link \}\}" target="_blank" rel="noopener noreferrer">\{\{ .title \}\}</a><span style="float:right;font-weight:400">\{\{ .type \}\}</span></div>
-          <div class="media-meta-item">
-            <span class="author">\{\{ .author \}\}</span>
-            <span class="star-score">\{\{ .starscore \}\}<span class="grey-star">\{\{ .greystar \}\}</span></span>
-          </div>
-          <div class="media-meta-item intro">\{\{ .intro | safeHTML \}\}</div>
-        </div>
-      </div>
+      {{- $cover := .coverurl | default "" -}}
+      {{- $link := .link | default "" -}}
+      <article class="media">
+        {{- if $cover -}}
+          <div class="media-cover" style="background-image:url({{ $cover }})" aria-hidden="true"></div>
+        {{- else -}}
+          <div class="media-cover media-cover-placeholder" aria-hidden="true"><span>{{ substr $title 0 1 }}</span></div>
+        {{- end -}}
+        <div class="media-meta">...</div>
+      </article>
     {{- end -}}
   {{- end -}}
-
-  {{- if eq $count 0 -}}
-    <p style="text-align: center; color: #888;">本年度暂无记录。</p>
-  {{- end -}}
-{{- else -}}
-  <p>警告：找不到数据文件 data/\{\{ $dataFile \}\}.yaml (或 .json/.toml)</p>
+</div>
+{{- if eq $count 0 -}}
+  <p class="mentalfood-empty">{{ $empty }}</p>
 {{- end -}}
 ```
 
-这个 shortcode 的工作原理：
+这样一来，新增一本书或一部电影时，我只需要补 YAML；卡片怎么排版、封面怎么显示、评分怎么着色、没有封面时怎么兜底，都是模板负责。
 
-1. `{{ $dataFile := .Get 0 }}` 获取第一个参数`（"books"）`
-2. `{{ $yearPrefix := .Get 1 }}` 获取第二个参数`（"24"）`
-3. `{{ range $mediaData }}` 遍历数据文件中的所有条目
-4. `{{ if (hasPrefix .type $yearPrefix) }}` 是最关键的一行，它检查每个条目的 type 字段（如 `"24-01"`）是否以我们传入的年份前缀（`"24"`）开头，只有匹配的条目才会被渲染成 HTML
-5. 还增加了一个计数器，如果某一年份下没有任何记录，会显示“本年度暂无记录”
+### 4. `medialist` 仍然保留，但已经不是主入口
 
-#### 3. 修改 Markdown 文件
+现在年度书影游页面主要走 `footprint-year.html` + `mentalfood/year.html` 这套新结构。不过原来的 `medialist` Shortcode 还保留在主题里：
 
-最后一步，就是把原来的 Markdown 文件里大段的 `mediacard` 调用，换成新的 `medialist`。
-
-**修改前 (2024年影剧部分):**
-```markdown
-{{</* admonition type=tip title="影剧（20部）" open=false */>}}
-  {{</* mediacard title="非诚勿扰3 (2023)" ... */>}}
-  {{</* mediacard title="葬送的芙莉莲 (2023)" ... */>}}
-  ... (还有很多条)
-{{</* /admonition */>}}
+```go-html-template
+{{- $dataFile := .Get 0 -}}
+{{- $yearPrefix := .Get 1 -}}
+{{- $mediaData := index site.Data $dataFile -}}
 ```
 
-**修改后:**
+它最初的使用方式是：
+
 ```markdown
-{{</* admonition type=tip title="影剧" open=false */>}}
-  {{</* medialist "movies" "24" */>}}
-{{</* /admonition */>}}
+{{</* medialist "books" "25" */>}}
 ```
-原来几十行的内容，现在一行就够了，整个 Markdown 文件清爽了很多。
+
+不过要注意：`medialist` 是早期「扁平数据 + 年份前缀过滤」阶段留下的过渡层，而现在主数据已经改成了外层按年份分组。因此新页面不再依赖它，主要使用 layout + partial 直接读取 `site.Data.books "2025"` 这种结构。这样 Markdown 里就不用再写展示逻辑，页面也更接近「声明年份和分类」的角色。
+
+## 为什么要按年份分组
+
+最开始用 Data Files 时，我只想着「不要把数据写在 Markdown 里」。当时把 `books.yaml`、`movies.yaml` 做成一个大列表，再用 `type` 前缀筛选年份，已经比原来好很多。
+
+但随着数据越来越多，这个结构又开始显得有点笨：
+
+- CMS 表单里不好按年份折叠；
+- 模板每次都要遍历全量数据；
+- 想检查某一年有没有漏记，需要在长列表里搜索；
+- 后续足迹页面本来就是年度维度，书影数据也应该跟它对齐。
+
+所以现在改成了外层年份 key：`"2025" -> 列表`。这样既方便 Hugo 模板 `index`，也方便 Pages CMS 把每一年做成独立字段。
+
+## Pages CMS 也接进来了
+
+这次数据结构调整还有一个现实原因：我现在已经把博客的很多编辑入口搬到了浏览器里。`.pages.yml` 里把这几份数据文件都配置成了可编辑表单：
+
+```yaml
+- name: data
+  label: Data 数据
+  type: group
+  items:
+    - name: books
+      label: 书刊清单
+      path: data/books.yaml
+    - name: movies
+      label: 影剧清单
+      path: data/movies.yaml
+    - name: mental_links
+      label: 精神食粮链接
+      path: data/mental_links.yaml
+    - name: footprint
+      label: 足迹表格
+      path: data/footprint.yaml
+```
+
+并且每类数据都有对应的组件定义。例如书刊和影剧都要求 `type` 使用 `YY-MM` 格式：
+
+```yaml
+pattern:
+  regex: "^[0-9]{2}-[0-9]{2}$"
+  message: "请使用 YY-MM 格式，例如 25-09。"
+```
+
+这一步挺关键的。只靠 YAML 文件当然也能维护，但字段一多之后，人总会写错。把它接进 Pages CMS 后，常用字段变成表单，`type` 这类容易写错的字段加上格式校验，日常更新就顺手很多。
+
+也就是说，Data Files 解决的是「数据不要混在正文里」；Pages CMS 进一步解决的是「编辑数据时不要每次都手写 YAML」。
 
 ## 最终效果
 
-这么修改之后，解决了之前维护困难的问题。
-- **Markdown 文件变干净了**，只负责页面结构，不再包含具体数据。
-- **数据管理方便**，所有条目都在 `.yaml` 文件里，一目了然。
-- **之后扩展也容易**，这些数据可以很方便地在网站其他地方复用。
+现在新增一条书影记录，大致流程是：
 
-总的来说，对 Hugo 这种需要管理大量结构化数据的情况，用 Data Files 功能是个不错的选择。
+1. 打开 Pages CMS 的 Data 数据入口；
+2. 选择 `books.yaml` 或 `movies.yaml`；
+3. 找到对应年份，比如 `2025`；
+4. 新增一条记录，填标题、封面、链接、作者、月份、评分和简评；
+5. 保存后由 Hugo 构建，年度书影游页面自动渲染出来。
+
+新增一条出游足迹也类似：只需要改 `data/footprint.yaml` 里对应分类、年份、月份下的 `events`，页面表格会自动更新。
+
+对我来说，最明显的变化是：Markdown 页面终于不用承担所有事情了。它只保留页面说明和少量结构，真正会持续增长的内容都进入了数据文件。后续无论是按年份展示、换卡片样式，还是把同一份数据复用到别的页面，都会轻松很多。
 
 ## 小结
 
-最终方案是用 `data/books.yaml`、`data/movies.yaml` 承载条目数据，再用 `medialist` Shortcode 按年份筛选并渲染。它牺牲了一点模板复杂度，换来了 Markdown 页面更清爽、数据更易批量维护的收益。后续可优化的方向，是继续抽象评分、分类和封面字段，并为数据文件增加更稳定的校验规则。
+这次折腾从一个很小的问题开始：书影记录页面里 Shortcode 太多，维护起来很烦。最初的解决方案是把书和电影拆到 `data/books.yaml`、`data/movies.yaml`，再用 `medialist` 按年份筛选。后来随着网站结构继续演进，这套思路扩展成了现在的四份核心数据文件：
+
+- `data/books.yaml`：书刊；
+- `data/movies.yaml`：影剧；
+- `data/mental_links.yaml`：文章、视频、播客等摘录；
+- `data/footprint.yaml`：出游、书影游、海报墙的年度表格。
+
+最终我更想保留的是这个边界：**数据放在 Data Files，页面声明年份和分类，layout / partial 负责组织与渲染，Pages CMS 负责降低编辑门槛。**
+
+这种方案不一定适合所有博客，但对于个人站点里那些「会不断增加、字段又比较固定」的内容来说，确实舒服很多。它没有让 Hugo 变复杂，反而让 Hugo 静态站点最擅长的事情更清楚了：用朴素的数据文件，生成稳定、可迁移、容易维护的页面。
 
 ## 参考资料
 
 - [Hugo Data Templates](https://gohugo.io/templates/data-templates/)
 - [Hugo Shortcodes](https://gohugo.io/content-management/shortcodes/)
+- [Pages CMS 配置文件](https://pagescms.org/docs/configuration/)
 
 （2025-08-28@深圳）

--- a/content/posts/2025/20250915.md
+++ b/content/posts/2025/20250915.md
@@ -9,72 +9,314 @@ comment: true
 toc: true
 ---
 
-本文解决的是 Hugo 博客目录（TOC）层级不够清晰、交互反馈偏弱的问题：在不改 JavaScript 的前提下，通过 SCSS 调整标记点、引导线、悬停态和容器样式，让长文目录更好读也更好用。
+本文解决的是 Hugo 博客目录（TOC）层级不够清晰、交互反馈偏弱的问题：在不改 Hugo 目录生成逻辑、也不改 JavaScript 交互逻辑的前提下，只通过 SCSS 调整标记点、引导线、悬停态和容器样式，让长文目录更好读也更好用。
+
+![](https://img.philohao.com/blog/2025/09/20250915-01.webp)
 
 ## 适用场景
 
-适合已经启用 Hugo 文章目录、但默认 TOC 在长文中显得层级混乱或视觉过轻的博客。尤其是经常写技术教程、读书笔记这类多级标题文章时，目录样式的可读性会直接影响阅读体验。
+适合已经启用 Hugo 文章目录、但默认 TOC 在长文中显得层级混乱或视觉过轻的博客。尤其是经常写技术教程、读书笔记、折腾记录这类多级标题文章时，目录样式的可读性会直接影响阅读体验。
+
+如果你的需求是「目录能生成，但看起来不够像一个好用的导航」，这篇就比较对症；如果你想改的是目录锚点生成、滚动监听或移动端抽屉，那就属于更底层的模板和 JS 改造了。
 
 ## 背景
 
 最近在看自己的网站时，觉得文章右侧的目录（Table of Contents）样式有些单调。它虽然能用，但在视觉上还有很大的提升空间。
 
-![](https://img.philohao.com/blog/2025/09/20250915-01.webp)
+原来的目录主要依赖简单圆点和缩进来表达层级。短文还好，一旦文章标题多起来，问题就明显了：一级、二级、三级标题之间的区分不够直观；鼠标移上去也没有明确反馈；浮动目录贴在页面边上时，存在感有点尴尬，既不像正文的一部分，也不像一个独立组件。
 
-可以看到，它只用了简单的圆点和缩进，层级关系不够直观，交互感也比较弱。我的目标是：在不修改任何 JavaScript 的前提下，只通过 CSS (SCSS) 来让它变得更美观、更实用。
+所以这次改造的目标其实很克制：**不推倒重来，只把原有 TOC 打磨得更像一个可读、可点、可维护的小导航**。
 
-## 核心步骤
+## 先看清楚原来的工作方式
 
-### 第一版改造：四大优化方向
+动手之前，我先把主题里和 TOC 有关的链路理了一遍。Aether 主题的目录并不是我手写出来的，而是沿用 Hugo 的 `.TableOfContents`，再由主题模板和 JS 决定它放在哪里、什么时候高亮。
 
-经过分析，我确定了四个主要的优化方向，并进行了第一轮的样式修改。
+### 1. Hugo 负责生成目录结构
 
-#### 1. 增强层级感
+在文章模板里，静态目录和浮动目录共用同一份 Hugo 输出：
 
-为了让目录结构一目了然，我做了两处关键改动：
+```go-html-template
+{{- dict "Content" .TableOfContents "Ruby" $params.ruby "Fraction" $params.fraction "Fontawesome" $params.fontawesome | partial "function/content.html" | safeHTML -}}
+```
 
-- **区分标记点**：用不同的符号来表示不同级别的标题。一级目录用实心圆 ●，二级目录用空心圆 ○，三级目录则用更细的 ◌。
-- **增加引导线**：在次级目录的左侧，增加一条垂直的引导线。这条线能非常清晰地将子标题“收纳”在父标题之下，结构感瞬间增强。
+也就是说，目录最核心的 HTML 结构来自 Hugo 本身。它通常会生成类似这样的嵌套列表：
 
-#### 2. 增加交互反馈
+```html
+<nav id="TableOfContents">
+  <ul>
+    <li><a href="#背景">背景</a></li>
+    <li>
+      <a href="#核心步骤">核心步骤</a>
+      <ul>
+        <li><a href="#增强层级感">增强层级感</a></li>
+      </ul>
+    </li>
+  </ul>
+</nav>
+```
 
-一个好的界面应该能对用户的操作做出反馈，之前的目录，鼠标放上去没有任何变化。
+这个结构有一个好处：天然就是 `ul > li > a > ul` 的树状结构。换句话说，层级关系其实已经在 HTML 里了，我没有必要为了视觉效果去改模板，只要让 CSS 更好地「读懂」这棵树就行。
 
-- **悬停效果 (:hover)**： 为每个目录链接添加了 :hover 伪类。当鼠标悬停在链接上时，会改变文字颜色并出现一个淡淡的背景色。这个简单的改动能明确告诉用户“这里可以点击”。
+### 2. 模板准备两个容器
 
-#### 3. 优化容器外观
+主题模板里同时准备了两个目录容器：
 
-无论是浮动目录还是静态目录，我都想让它们看起来更像一个精心设计的“卡片”，而不是简单的文字列表。
+- `#toc-auto`：桌面端右侧浮动目录；
+- `#toc-static`：正文里的静态折叠目录。
 
-- 浮动目录 (#toc-auto)： 为其增加了半透明的背景和右侧的圆角。这样即使页面背景复杂，目录依然清晰可读。
-- 静态目录 (#toc-static)： 将其从类似代码块的深色背景，改为了带有圆角和细边框的简洁样式，更好地融入文章内容。
+浮动目录先给一个空容器：
 
-#### 4. 调整布局方式
+```html
+<div class="toc" id="toc-auto">
+  <h2 class="toc-title">目录</h2>
+  <div class="toc-content" id="toc-content-auto"></div>
+</div>
+```
 
-放弃了原先 text-indent 的缩进方式，改用 position: relative 和 padding-left 来布局，这样能更精确地控制标记点和文字的位置，避免错位问题。
+静态目录则放在正文标题之后、文章内容之前：
 
-### 第二版微调：优化行间距
+```html
+<div class="details toc" id="toc-static">
+  <div class="details-summary toc-title">...</div>
+  <div class="details-content toc-content" id="toc-content-static">
+    {{ .TableOfContents }}
+  </div>
+</div>
+```
 
-第一版改造后，整体效果已经很不错了，但我发现一个细节问题：每一行的行间距似乎有点大，目录显得有些松散。
+这里的设计挺巧妙：页面上只有一份真正的 `#TableOfContents`，但它可以被放进不同容器。也正因为如此，我这次改样式时尽量把通用规则写在 `.toc` 下，再针对 `#toc-auto` 和 `#toc-static` 分别补外观。
 
-这个问题主要来源于我为了增加链接点击区域而在 a 标签上设置的 padding 值。
+### 3. JavaScript 负责搬运和高亮
 
-调整方法很简单：
+主题的 `initToc()` 会判断当前该使用静态目录还是浮动目录，然后把 `#TableOfContents` 移到对应容器中。如果使用浮动目录，它还会做三件事：
 
-找到 `.toc .toc-content ul a` 选择器，将其 padding 的垂直值从 4px 或 2px 直接改为 0。
+1. 根据文章区域位置计算 `#toc-auto` 的 `left` 和 `maxWidth`；
+2. 根据滚动位置在 `absolute` 和 `fixed` 之间切换；
+3. 给当前标题对应的目录链接加上 `.active`，同时给父级 `li` 加上 `.has-active`。
 
-修改前： `padding: 2px 0;`
+这就解释了为什么我不想碰 JS：滚动定位、当前阅读位置、高亮父级这些逻辑本来就是通的。我要解决的是「这些状态出现以后，视觉上怎么表达得更清楚」。
 
-修改后： `padding: 0 0;`
+## 设计原则
 
-同时，也移除了层级之间 ul 的 margin 值，让整个列表更加紧凑。
+理清底层以后，这次改造就不是简单地「加点好看的 CSS」，而是围绕几个限制来做取舍。
 
+### 1. 不改目录语义
+
+目录本质上还是一个导航列表，所以我保留 Hugo 生成的 `nav / ul / li / a` 结构，不额外包裹 span，也不在模板里塞装饰字符。层级标记全部交给 `::before` 伪元素，这样 HTML 仍然干净，后续换主题或排查锚点问题也更安心。
+
+### 2. 通用样式优先，容器样式分开
+
+`.toc` 里只放「目录作为列表」的通用规则，例如字号、列表重置、链接布局、层级标记、引导线、hover 状态。
+
+`#toc-auto` 和 `#toc-static` 则只负责各自的容器气质：浮动目录更像贴在页面右侧的轻量导航卡片；静态目录更像正文中的折叠信息块。这样拆开后，哪怕以后移动端或桌面端显示策略变了，列表本身的层级表达也不用重写。
+
+### 3. 尽量接入主题变量
+
+颜色没有写死成某一个蓝色或灰色，而是优先使用主题已有变量，比如 `$single-link-hover-color`、`$global-border-color`、`$code-background-color`。这样浅色、深色、黑色三套主题能一起适配，不会出现浅色主题好看、深色主题突然刺眼的问题。
+
+当然，这也带来一个小取舍：这份 SCSS 不是完全独立的组件，迁移到别的主题时，需要先把这些变量替换成目标主题自己的颜色体系。
+
+## 核心改造
+
+### 1. 用伪元素表达层级，而不是依赖默认圆点
+
+原来的目录层级主要靠浏览器默认列表样式和缩进。这个方案能用，但视觉信息太弱。我的改法是先把默认列表样式拿掉：
+
+```scss
+.toc {
+  .toc-content {
+    ul {
+      padding-left: 0;
+      list-style: none;
+    }
+  }
+}
+```
+
+然后把每个链接变成可定位的块级元素：
+
+```scss
+.toc .toc-content ul a {
+  display: block;
+  position: relative;
+  padding-left: 1.35rem;
+  text-decoration: none;
+}
+```
+
+这里的 `padding-left: 1.35rem` 很关键，它不是单纯缩进文字，而是给左侧的伪元素预留一个稳定位置。后面无论是实心圆、空心圆，还是高亮状态，都可以画在这块区域里，文字本身不会跟着晃。
+
+层级标记则用直接子代选择器区分：
+
+```scss
+.toc .toc-content ul > li > a::before {
+  content: "●";
+}
+
+.toc .toc-content ul ul > li > a::before {
+  content: "○";
+}
+
+.toc .toc-content ul ul ul > li > a::before {
+  content: "◌";
+}
+```
+
+这里我选择 `● / ○ / ◌`，不是为了花哨，而是因为它们在小字号下仍然比较容易分辨：一级标题更重，二级标题更轻，三级标题再往后退一点。读者扫一眼目录，就能大概知道文章骨架。
+
+### 2. 用引导线把子标题「收」到父标题下面
+
+只有不同圆点还不够，长文里多个二级、三级标题连续出现时，眼睛还是容易飘。所以我给子级 `ul` 增加了一条细引导线：
+
+```scss
+.toc .toc-content ul ul {
+  padding-left: 1rem;
+  position: relative;
+}
+
+.toc .toc-content ul ul::before {
+  content: '';
+  position: absolute;
+  left: 0.35rem;
+  top: 0.5rem;
+  bottom: 0.5rem;
+  width: 1px;
+  background-color: $global-border-color;
+}
+```
+
+这条线的作用不是装饰，而是帮助眼睛理解「这一组小标题属于上面的父标题」。尤其是浮动目录宽度有限时，文字会换行，如果没有这条线，层级关系就更容易散掉。
+
+`top` 和 `bottom` 没有写成 `0`，是为了让线条不要顶到整组列表的边缘，视觉上会轻一点，也不会像表格边框一样生硬。
+
+### 3. hover 反馈要明显，但不能抢正文
+
+目录是导航，鼠标移上去应该有反馈。我的处理是文字变成链接 hover 色，同时给一个很淡的背景：
+
+```scss
+.toc .toc-content ul a:hover {
+  color: $single-link-hover-color;
+  background-color: rgba($global-border-color, 0.5);
+  border-radius: 4px;
+}
+```
+
+这个背景色故意取得很轻，因为目录始终是辅助组件，不能比正文内容更抢眼。真正需要强调的是「这里可以点击」，而不是做成按钮一样的强交互。
+
+深色和黑色主题则单独降低透明度：
+
+```scss
+[theme=dark] & {
+  color: $single-link-hover-color-dark;
+  background-color: rgba($global-border-color-dark, 0.2);
+}
+```
+
+深色模式下如果透明度过高，hover 背景会显得一块一块的，反而不耐看。这里用 `0.2`，基本就是给用户一个轻提示。
+
+### 4. active 状态复用 hover 色
+
+浮动目录有滚动高亮逻辑，JS 会给当前目录链接加 `.active`。所以样式上我让 active 链接加粗，并复用 hover 色：
+
+```scss
+#toc-auto .toc-content ul a.active {
+  font-weight: bold;
+  color: $single-link-hover-color;
+}
+
+#toc-auto .toc-content ul a.active::before {
+  color: $single-link-hover-color;
+}
+```
+
+这里有一个小细节：不仅文字要变色，前面的圆点也要一起变色。否则当前标题虽然高亮了，但标记点还停留在默认颜色，会有一点割裂。
+
+同时，主题 JS 会给 active 链接的父级加 `.has-active`。原样式里子级目录默认折叠，我保留了这个逻辑：
+
+```scss
+#toc-auto .toc-content ul ul {
+  display: none;
+}
+
+#toc-auto .toc-content ul .has-active > ul {
+  display: block;
+}
+```
+
+这样浮动目录不会一次性把所有层级都摊开，而是跟着当前阅读位置展开相关分支。对长文来说，这比完整展开更清爽。
+
+### 5. 浮动目录做成轻量卡片
+
+浮动目录原本更像一列贴在旁边的文字。我希望它更像一个「独立但不突兀」的导航卡片，所以加了内边距、边框、圆角和背景模糊：
+
+```scss
+#toc-auto {
+  padding: 0 1rem;
+  border: 1px solid #b1b1b1;
+  border-left: 3px solid $global-border-color;
+  border-radius: 0 8px 8px 0;
+  @include blur;
+}
+```
+
+这里左边框比其他边更粗，是为了保留一点「侧边导航」的感觉；右侧圆角则让它不要像浏览器原生边框那么硬。`@include blur` 继续沿用主题已有的毛玻璃效果，和站内其他组件保持一致。
+
+不过它仍然由 JS 控制位置：初始 `visibility: hidden`，等 `initToc()` 算好文章右侧位置后再显示。这样可以避免页面刚加载时目录闪一下。
+
+### 6. 静态目录融入正文
+
+静态目录在正文里出现时，读者会把它当成文章内容的一部分，所以我没有给它做太强的浮层感，而是改成边框卡片：
+
+```scss
+#toc-static {
+  margin: 1.5rem 0;
+  border: 1px solid $global-border-color;
+  border-radius: 8px;
+  overflow: hidden;
+}
+```
+
+标题栏继续使用代码块背景色：
+
+```scss
+#toc-static .toc-title {
+  display: flex;
+  justify-content: space-between;
+  line-height: 2em;
+  padding: 0.5rem 1rem;
+  background: $code-background-color;
+  cursor: pointer;
+}
+```
+
+`cursor: pointer` 是一个很小但很重要的提示，因为静态目录本质上是可折叠的 details 组件。用户看到鼠标样式变化，就会知道标题栏不是普通文本。
+
+### 7. 行间距最后再收紧
+
+第一版改完后，整体效果已经出来了，但目录看起来还有点松散。问题主要来自链接的上下 `padding`：我一开始为了扩大点击区域，给了 `2px 0`，结果目录项一多就显得臃肿。
+
+最后我把它收成：
+
+```scss
+padding: 0 0;
+padding-left: 1.35rem;
+```
+
+注意这里不是把点击体验完全牺牲掉，而是因为目录本身有行高，链接又是 `display: block`，实际可点区域仍然够用。对于右侧浮动目录这种窄组件来说，紧凑一点反而更适合。
 
 ## 最终效果
 
-改造后的目录用不同符号和缩进表达层级，用 hover 状态提示可点击区域，并让浮动目录、静态目录都更像页面中的信息卡片。视觉上不会喧宾夺主，但足够支撑长文快速跳转。
+改造后的目录主要解决了三个问题：
+
+1. **层级更清楚**：不同标记点加上子级引导线，标题树更容易扫读；
+2. **状态更明确**：hover 和 active 都有颜色反馈，当前阅读位置更好判断；
+3. **容器更完整**：浮动目录像侧边导航卡片，静态目录像正文信息块，两者都不再只是散落的文字列表。
+
+这次我比较满意的地方在于，它没有改变 Hugo 的目录生成方式，也没有动主题原有的滚动监听。目录仍然是那份目录，只是 CSS 更准确地把它的结构和状态表达出来了。
 
 ## 最终代码展示
+
+下面是这次改造后的核心 SCSS，主要对应主题里的 `themes/aether/assets/css/_partial/_single/_toc.scss`：
 
 ```scss
 // --- 变量定义 (假设这些变量已在别处定义) ---
@@ -96,24 +338,22 @@ toc: true
   .toc-content {
     font-size: $toc-content-font-size;
 
-    // --- 移除 text-indent, 使用更现代的 Flexbox/Grid 或伪元素布局 ---
+    // --- 移除 text-indent，改用伪元素和 padding-left 控制层级 ---
     ul {
-      padding-left: 0; // 重置内边距, 在 a 标签上控制
+      padding-left: 0;
       list-style: none;
 
       a {
-        // --- 优化: 将 a 标签设为块级或行内块, 方便添加 padding 和 hover 背景 ---
         display: block;
-        padding: 0 0; // --- 调整这里 (1): 减小链接的上下内边距来缩小行距 ---
+        padding: 0 0;
         position: relative;
-        padding-left: 1.35rem; // 为伪元素留出空间
-        text-decoration: none; // 确保没有下划线
-        transition: color 0.2s, background-color 0.2s; // 平滑过渡
+        padding-left: 1.35rem;
+        text-decoration: none;
+        transition: color 0.2s, background-color 0.2s;
 
-        // --- 新增: 鼠标悬停效果 ---
         &:hover {
           color: $single-link-hover-color;
-          background-color: rgba($global-border-color, 0.5); // 添加一个淡淡的背景色
+          background-color: rgba($global-border-color, 0.5);
           border-radius: 4px;
 
           [theme=dark] & {
@@ -127,10 +367,8 @@ toc: true
         }
       }
 
-      // --- 优化: 使用 > 选择器区分层级 ---
-      // Level 1
       > li > a::before {
-        content: "●"; // 使用实心圆点作为一级标记
+        content: "●";
         font-weight: bolder;
         position: absolute;
         left: 0;
@@ -142,17 +380,13 @@ toc: true
       }
 
       ul {
-        padding-left: 1rem; // 子列表的缩进
-        // --- 调整这里 (2): 减小层级之间的垂直间距 ---
-        // margin-top: 0.1rem;
-        // margin-bottom: 0.1rem;
-
-        // --- 新增: 视觉引导线 ---
+        padding-left: 1rem;
         position: relative;
+
         &::before {
           content: '';
           position: absolute;
-          left: 0.35rem; // 调整线的位置
+          left: 0.35rem;
           top: 0.5rem;
           bottom: 0.5rem;
           width: 1px;
@@ -161,20 +395,17 @@ toc: true
           [theme=black] & { background-color: $global-border-color-black; }
         }
 
-        // Level 2
         > li > a::before {
-          content: "○"; // 使用空心圆点
+          content: "○";
         }
 
-        // Level 3 (如果需要)
         ul > li > a::before {
-          content: "◌"; // 使用更小的空心圆点
+          content: "◌";
         }
       }
     }
   }
 
-  // --- ruby 样式 ---
   ruby {
     background: $code-background-color;
 
@@ -205,17 +436,15 @@ toc: true
   position: absolute;
   width: $MAX_LENGTH;
   max-width: 0;
-  // --- 优化: 增加内边距, 让内容有呼吸空间 ---
   padding: 0 1rem;
-  border-left: 3px solid $global-border-color; // 边框稍微细一点
+  border: 1px solid #b1b1b1;
+  border-left: 3px solid $global-border-color;
   @include overflow-wrap(break-word);
   box-sizing: border-box;
   top: 10rem;
   left: 0;
   visibility: hidden;
-
-  // --- 新增: 半透明背景, 提升可读性 ---
-  border-radius: 0 8px 8px 0; // 右侧添加圆角
+  border-radius: 0 8px 8px 0;
   @include blur;
 
   [theme=dark] & {
@@ -235,10 +464,9 @@ toc: true
 
   .toc-content {
     ul {
-      // --- 优化: 为 active 状态的伪元素也应用高亮颜色 ---
       a.active {
         font-weight: bold;
-        color: $single-link-hover-color; // 使用 hover 颜色以示强调
+        color: $single-link-hover-color;
         [theme=dark] & { color: $single-link-hover-color-dark; }
         [theme=black] & { color: $single-link-hover-color-black; }
 
@@ -268,13 +496,13 @@ toc: true
   }
 }
 
-// --- 静态目录 (页面内) ---
+// --- 静态目录（页面内） ---
 #toc-static {
   display: none;
-  margin: 1.5rem 0; // 增加上下边距
-  border: 1px solid $global-border-color; // --- 优化: 使用边框代替背景色, 更简洁
+  margin: 1.5rem 0;
+  border: 1px solid $global-border-color;
   border-radius: 8px;
-  overflow: hidden; // 配合圆角
+  overflow: hidden;
 
   [theme=dark] & { border-color: $global-border-color-dark; }
   [theme=black] & { border-color: $global-border-color-black; }
@@ -289,18 +517,18 @@ toc: true
     line-height: 2em;
     padding: 0.5rem 1rem;
     background: $code-background-color;
-    cursor: pointer; // --- 新增: 表明标题可点击
+    cursor: pointer;
 
     [theme=dark] & { background: $code-background-color-dark; }
     [theme=black] & { background: $code-background-color-black; }
   }
 
   .toc-content {
-    background-color: transparent; // --- 优化: 移除背景色, 使其与文章背景一致
+    background-color: transparent;
 
     > nav > ul {
       margin: 0;
-      padding: .8rem 1rem .8rem 1rem; // 统一内边距
+      padding: .8rem 1rem .8rem 1rem;
     }
   }
 }
@@ -308,7 +536,11 @@ toc: true
 
 ## 小结
 
-最终方案是保留 Hugo 原有 TOC 生成逻辑，只在 SCSS 层做视觉增强。这样风险较低，不会影响目录锚点和滚动定位；取舍是样式对主题变量依赖较强，迁移到其他主题时需要重新适配。后续可以继续优化移动端折叠、当前阅读位置高亮，以及多级标题过深时的显示策略。
+这次 TOC 改造看起来只是改样式，但真正重要的是先弄清楚边界：Hugo 负责生成目录结构，模板负责提供静态和浮动两个容器，JavaScript 负责搬运目录与滚动高亮，而 SCSS 负责把层级、状态和容器气质表达清楚。
+
+最终方案的优点是风险比较低：不影响目录锚点，不影响滚动定位，也不需要维护额外脚本；缺点是样式和 Aether 主题变量绑定较深，迁移到其他主题时需要重新适配。
+
+后续如果继续优化，我可能会再看看移动端折叠目录、当前阅读位置的过渡动画，以及多级标题过深时是否需要限制显示层级。但当前这个版本已经足够解决一个很实际的问题：长文目录终于不再只是「能用」，而是开始「好读」了。
 
 ## 参考资料
 


### PR DESCRIPTION
### Motivation
- Clarify and expand the writeup about moving structured content out of Markdown into Hugo `data/` files and show a year-grouped data model and Pages CMS integration. 
- Improve documentation and examples so the `books`, `movies`, `mental_links` and `footprint` data flows are clearer for maintenance and reuse.
- Visually improve the Table of Contents (TOC) by providing a CSS-first solution that enhances hierarchy, hover/active feedback and container styling without touching Hugo's TOC generation or JS.

### Description
- Edited `content/posts/2025/20250828.md` to replace the original mediacard/medialist narrative with expanded guidance, YAML examples, a year-keyed data layout (`data/books.yaml`, `data/movies.yaml`, `data/mental_links.yaml`, `data/footprint.yaml`) and Pages CMS form integration examples using `type: YY-MM` validation. 
- Reworked text to emphasize the pattern: pages declare `year`/`category` and `layouts/partials/mentalfood/year.html` aggregates and renders year-scoped `site.Data` entries; kept notes about legacy `medialist` shortcode as a transitional path. 
- Edited `content/posts/2025/20250915.md` to add a full SCSS-driven TOC redesign, including concrete SCSS snippets that remove list-indent, add pseudo-element markers (`●/○/◌`), vertical guide lines, hover/active styles, and distinct container styles for `#toc-auto` and `#toc-static`, while preserving existing Hugo/JS responsibilities. 
- Adjusted prose, examples and inline code blocks across both posts to reflect the new data structure, rendering partials, and styling decisions; no structural site templates were changed in this PR (only post content and illustrative SCSS samples).

### Testing
- No automated tests were run for these content and example updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a083f48ba6483218029fae3528c2f7d)